### PR TITLE
ref: Accept client-side wayland connection, global

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,6 +963,7 @@ dependencies = [
  "libwaysip",
  "tracing",
  "tracing-subscriber",
+ "wayland-client",
 ]
 
 [[package]]

--- a/libwaysip/examples/base.rs
+++ b/libwaysip/examples/base.rs
@@ -1,4 +1,27 @@
 use libwaysip::{get_area, SelectionType};
+use wayland_client::{
+    globals::{registry_queue_init, GlobalListContents},
+    protocol::wl_registry,
+    Connection, Dispatch, QueueHandle,
+};
+
+struct State {}
+
+impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for State {
+    fn event(
+        _: &mut State,
+        _: &wl_registry::WlRegistry,
+        _: wl_registry::Event,
+        _: &GlobalListContents,
+        _: &Connection,
+        _: &QueueHandle<State>,
+    ) {
+    }
+}
+
 fn main() {
-    println!("{:?}", get_area(SelectionType::Area));
+    let connection = Connection::connect_to_env().unwrap();
+    let (globals, _) = registry_queue_init::<State>(&connection).unwrap();
+
+    println!("{:?}", get_area(&connection, globals, SelectionType::Area));
 }

--- a/libwaysip/src/dispatch.rs
+++ b/libwaysip/src/dispatch.rs
@@ -62,9 +62,9 @@ impl Dispatch<zxdg_output_v1::ZxdgOutputV1, ()> for WaysipState {
         _qhandle: &wayland_client::QueueHandle<Self>,
     ) {
         let Some(info) = state
-            .zxdgoutputs
+            .zxdg_outputs
             .iter_mut()
-            .find(|info| info.zxdgoutput == *proxy)
+            .find(|info| info.zxdg_output == *proxy)
         else {
             return;
         };
@@ -84,7 +84,6 @@ impl Dispatch<zxdg_output_v1::ZxdgOutputV1, ()> for WaysipState {
     }
 }
 
-// so interesting, it is just need to invoke once, it just used to get the globals
 impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for state::WaysipState {
     fn event(
         _state: &mut Self,
@@ -259,8 +258,8 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                     .position(|info| info.wl_surface == surface)
                     .unwrap();
                 dispatch_state.current_screen = current_screen;
-                let start_x = dispatch_state.zxdgoutputs[dispatch_state.current_screen].start_x;
-                let start_y = dispatch_state.zxdgoutputs[dispatch_state.current_screen].start_y;
+                let start_x = dispatch_state.zxdg_outputs[dispatch_state.current_screen].start_x;
+                let start_y = dispatch_state.zxdg_outputs[dispatch_state.current_screen].start_y;
                 dispatch_state.current_pos =
                     (surface_x + start_x as f64, surface_y + start_y as f64);
 
@@ -291,8 +290,8 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                 surface_y,
                 ..
             } => {
-                let start_x = dispatch_state.zxdgoutputs[dispatch_state.current_screen].start_x;
-                let start_y = dispatch_state.zxdgoutputs[dispatch_state.current_screen].start_y;
+                let start_x = dispatch_state.zxdg_outputs[dispatch_state.current_screen].start_x;
+                let start_y = dispatch_state.zxdg_outputs[dispatch_state.current_screen].start_y;
                 dispatch_state.current_pos =
                     (surface_x + start_x as f64, surface_y + start_y as f64);
                 if dispatch_state.is_area() {

--- a/libwaysip/src/lib.rs
+++ b/libwaysip/src/lib.rs
@@ -8,7 +8,7 @@ use error::WaySipError;
 pub use state::SelectionType;
 use std::os::unix::prelude::AsFd;
 use wayland_client::{
-    globals::registry_queue_init,
+    globals::GlobalList,
     protocol::{
         wl_compositor::WlCompositor,
         wl_seat::WlSeat,
@@ -36,19 +36,12 @@ fn get_cursor_buffer(connection: &Connection, shm: &WlShm) -> Option<CursorImage
 }
 
 /// get the selected area
-pub fn get_area(kind: SelectionType) -> Result<Option<state::AreaInfo>, WaySipError> {
-    let connection =
-        Connection::connect_to_env().map_err(|e| WaySipError::InitFailed(e.to_string()))?;
-    let (globals, _) = registry_queue_init::<state::WaysipState>(&connection)
-        .map_err(|e| WaySipError::InitFailed(e.to_string()))?; // We just need the
-                                                               // global, the
-                                                               // event_queue is
-                                                               // not needed, we
-                                                               // do not need
-                                                               // state::BaseState after
-                                                               // this anymore
-
-    let mut state = state::WaysipState::new(kind);
+pub fn get_area(
+    connection: &Connection,
+    globals: GlobalList,
+    selection_type: SelectionType,
+) -> Result<Option<state::AreaInfo>, WaySipError> {
+    let mut state = state::WaysipState::new(selection_type);
 
     let mut event_queue = connection.new_event_queue::<state::WaysipState>();
     let qh = event_queue.handle();
@@ -93,7 +86,7 @@ pub fn get_area(kind: SelectionType) -> Result<Option<state::AreaInfo>, WaySipEr
     for wloutput in state.outputs.iter() {
         let zwloutput = xdg_output_manager.get_xdg_output(wloutput.get_output(), &qh, ());
         state
-            .zxdgoutputs
+            .zxdg_outputs
             .push(state::ZXdgOutputInfo::new(zwloutput));
     }
 
@@ -115,7 +108,7 @@ pub fn get_area(kind: SelectionType) -> Result<Option<state::AreaInfo>, WaySipEr
     for (index, (wloutput, zwlinfo)) in state
         .outputs
         .iter()
-        .zip(state.zxdgoutputs.iter())
+        .zip(state.zxdg_outputs.iter())
         .enumerate()
     {
         let wl_surface = wmcompositer.create_surface(&qh, ()); // and create a surface. if two or more,

--- a/libwaysip/src/state.rs
+++ b/libwaysip/src/state.rs
@@ -18,7 +18,7 @@ pub enum SelectionType {
 
 #[derive(Debug)]
 pub struct ZXdgOutputInfo {
-    pub zxdgoutput: zxdg_output_v1::ZxdgOutputV1,
+    pub zxdg_output: zxdg_output_v1::ZxdgOutputV1,
     pub width: i32,
     pub height: i32,
     pub start_x: i32,
@@ -30,7 +30,7 @@ pub struct ZXdgOutputInfo {
 impl ZXdgOutputInfo {
     pub fn new(zxdgoutput: zxdg_output_v1::ZxdgOutputV1) -> Self {
         Self {
-            zxdgoutput,
+            zxdg_output: zxdgoutput,
             width: 0,
             height: 0,
             start_x: 0,
@@ -130,9 +130,9 @@ impl ScreenInfo {
 #[derive(Debug)]
 pub struct WaysipState {
     pub outputs: Vec<WlOutputInfo>,
-    pub zxdgoutputs: Vec<ZXdgOutputInfo>,
+    pub zxdg_outputs: Vec<ZXdgOutputInfo>,
     pub running: bool,
-    pub waysipkind: SelectionType,
+    pub selection_type: SelectionType,
     pub wl_surfaces: Vec<LayerSurfaceInfo>,
     pub current_pos: (f64, f64),
     pub start_pos: Option<(f64, f64)>,
@@ -142,12 +142,12 @@ pub struct WaysipState {
 }
 
 impl WaysipState {
-    pub fn new(waysipkind: SelectionType) -> Self {
+    pub fn new(selection_type: SelectionType) -> Self {
         WaysipState {
             outputs: Vec::new(),
-            zxdgoutputs: Vec::new(),
+            zxdg_outputs: Vec::new(),
             running: true,
-            waysipkind,
+            selection_type,
             wl_surfaces: Vec::new(),
             current_pos: (0., 0.),
             start_pos: None,
@@ -158,11 +158,11 @@ impl WaysipState {
     }
 
     pub fn is_area(&self) -> bool {
-        matches!(self.waysipkind, SelectionType::Area)
+        matches!(self.selection_type, SelectionType::Area)
     }
 
     pub fn is_screen(&self) -> bool {
-        matches!(self.waysipkind, SelectionType::Screen)
+        matches!(self.selection_type, SelectionType::Screen)
     }
 
     pub fn redraw_screen(&self) {
@@ -181,7 +181,7 @@ impl WaysipState {
             .wl_surfaces
             .iter()
             .enumerate()
-            .zip(self.zxdgoutputs.iter())
+            .zip(self.zxdg_outputs.iter())
         {
             info.redraw_select_screen(
                 self.current_screen == index,
@@ -206,7 +206,7 @@ impl WaysipState {
                 ..
             },
             layershell_info,
-        ) in self.zxdgoutputs.iter().zip(self.wl_surfaces.iter())
+        ) in self.zxdg_outputs.iter().zip(self.wl_surfaces.iter())
         {
             layershell_info.redraw(
                 (pos_x, pos_y),
@@ -224,7 +224,7 @@ impl WaysipState {
         let (start_x, start_y) = self.start_pos.unwrap();
         let (end_x, end_y) = self.end_pos.unwrap();
         let output = self.outputs[self.current_screen].clone();
-        let info = &self.zxdgoutputs[self.current_screen];
+        let info = &self.zxdg_outputs[self.current_screen];
         Some(AreaInfo {
             start_x,
             start_y,

--- a/waysip/Cargo.toml
+++ b/waysip/Cargo.toml
@@ -16,3 +16,4 @@ clap = { version = "4.4.10", features = ["derive"] }
 libwaysip.workspace = true
 tracing.workspace = true
 tracing-subscriber = "0.3"
+wayland-client = "0.31.2"

--- a/waysip/src/main.rs
+++ b/waysip/src/main.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
-use libwaysip::{get_area, SelectionType};
+use libwaysip::{error::WaySipError, get_area, state, SelectionType};
 use std::str::FromStr;
+use wayland_client::{globals::registry_queue_init, Connection};
 
 #[derive(Debug, Parser)]
 #[command(name = "waysip")]
@@ -22,6 +23,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_writer(std::io::stderr)
         .init();
 
+    let connection =
+        Connection::connect_to_env().map_err(|e| WaySipError::InitFailed(e.to_string()))?;
+
+    let (globals, _) = registry_queue_init::<state::WaysipState>(&connection)
+        .map_err(|e| WaySipError::InitFailed(e.to_string()))?;
+
     let args = Cli::parse();
 
     // TODO: Enable tracing
@@ -29,7 +36,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     macro_rules! get_info {
         ($x: expr) => {
-            match get_area($x) {
+            match get_area(&connection, globals, $x) {
                 Ok(Some(info)) => info,
                 Ok(None) => {
                     eprintln!("Get None, you cancel it");


### PR DESCRIPTION
Clients should be able to provide their own connection and global list instead of wasting time on another roundtrip / causing a segfault due to two open wayland-connections