### PR TITLE
Implementing slurp features v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +362,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "indexmap"
@@ -936,6 +956,7 @@ dependencies = [
 name = "waysip"
 version = "0.5.0-dev"
 dependencies = [
+ "atty",
  "clap",
  "libwaysip",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ readme = "README.md"
 [workspace.dependencies]
 libwaysip = { version = "0.5.0-dev", path = "./libwaysip" }
 tracing = "0.1"
+

--- a/libwaysip/examples/base.rs
+++ b/libwaysip/examples/base.rs
@@ -31,6 +31,8 @@ fn main() {
             .with_border_weight(2.0)
             .with_font_size(12)
             .with_font_name("Sans".to_string())
+            .with_predefined_boxes(Vec::new())
+            .with_aspect_ratio(16.0, 9.0)
             .get()
     );
 }

--- a/libwaysip/examples/base.rs
+++ b/libwaysip/examples/base.rs
@@ -28,6 +28,7 @@ fn main() {
             .with_background_color(Color::default())
             .with_foreground_color(Color::default())
             .with_border_text_color(Color::default())
+            .with_box_color(Color::default())
             .with_border_weight(2.0)
             .with_font_size(12)
             .with_font_name("Sans".to_string())

--- a/libwaysip/src/dispatch.rs
+++ b/libwaysip/src/dispatch.rs
@@ -334,8 +334,7 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                         dispatch_state.commit();
                         dispatch_state.last_redraw = now;
                     }
-                }
-                if dispatch_state.is_predefined_boxes() {
+                } else if dispatch_state.is_predefined_boxes() {
                     let current_pos = dispatch_state.current_pos;
                     if let Some(box_info) = dispatch_state
                         .predefined_boxes

--- a/libwaysip/src/dispatch.rs
+++ b/libwaysip/src/dispatch.rs
@@ -302,7 +302,7 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                 if dispatch_state.is_area() {
                     let now = std::time::Instant::now();
                     if now.duration_since(dispatch_state.last_redraw)
-                        >= std::time::Duration::from_millis(10)
+                        >= std::time::Duration::from_millis(8)
                     {
                         dispatch_state.commit();
                         dispatch_state.last_redraw = now;

--- a/libwaysip/src/error.rs
+++ b/libwaysip/src/error.rs
@@ -25,3 +25,15 @@ pub enum ColorError {
     #[error("Invalid color value: {0}")]
     ParseIntError(#[from] std::num::ParseIntError),
 }
+
+#[derive(Debug, Error)]
+pub enum BoxInfoError {
+    #[error("Invalid string format for Box `{0}`, expected `x,y WIDTHxHEIGHT`")]
+    InvalidBoxString(String),
+    #[error("Invalid box coordinates string `{0}`, expected `x,y`")]
+    InvalidBoxCoordsString(String),
+    #[error("Invalid box size string `{0}`, expected `WIDTHxHEIGHT`")]
+    InvalidBoxSizeString(String),
+    #[error("Invalid box info value: {0}")]
+    ParseFloatError(#[from] std::num::ParseFloatError),
+}

--- a/libwaysip/src/lib.rs
+++ b/libwaysip/src/lib.rs
@@ -44,6 +44,7 @@ pub struct WaySip {
     selection_type: SelectionType,
     style: Style,
     predefined_boxes: Option<Vec<state::BoxInfo>>,
+    aspect_ratio: Option<(f64, f64)>,
 }
 
 impl WaySip {
@@ -93,6 +94,11 @@ impl WaySip {
         self
     }
 
+    pub fn with_aspect_ratio(mut self, width: f64, height: f64) -> Self {
+        self.aspect_ratio = Some((width, height));
+        self
+    }
+
     /// get the selected area
     pub fn get(self) -> Result<Option<state::AreaInfo>, WaySipError> {
         match self.conn {
@@ -101,6 +107,7 @@ impl WaySip {
                 self.selection_type,
                 self.style,
                 self.predefined_boxes,
+                self.aspect_ratio,
             ),
             None => {
                 let connection = Connection::connect_to_env()
@@ -111,6 +118,7 @@ impl WaySip {
                     self.selection_type,
                     self.style,
                     self.predefined_boxes,
+                    self.aspect_ratio,
                 )
             }
         }
@@ -122,12 +130,14 @@ fn get_area_inner(
     selection_type: SelectionType,
     style: Style,
     boxes: Option<Vec<state::BoxInfo>>,
+    aspect_ratio: Option<(f64, f64)>,
 ) -> Result<Option<state::AreaInfo>, WaySipError> {
     let (globals, _) = registry_queue_init::<state::WaysipState>(connection)
         .map_err(|e| WaySipError::InitFailed(e.to_string()))?;
     let mut state = state::WaysipState::new(selection_type);
 
     state.predefined_boxes = boxes;
+    state.aspect_ratio = aspect_ratio;
 
     let mut event_queue = connection.new_event_queue::<state::WaysipState>();
     let qh = event_queue.handle();

--- a/libwaysip/src/lib.rs
+++ b/libwaysip/src/lib.rs
@@ -8,7 +8,7 @@ pub use utils::*;
 
 use error::WaySipError;
 use render::UiInit;
-pub use state::{BoxInfo, SelectionType};
+pub use state::{AreaInfo, BoxInfo, SelectionType};
 use std::os::unix::prelude::AsFd;
 use wayland_client::{
     Connection,

--- a/libwaysip/src/lib.rs
+++ b/libwaysip/src/lib.rs
@@ -76,6 +76,10 @@ impl WaySip {
         self.style.border_text_color = color;
         self
     }
+    pub fn with_box_color(mut self, color: Color) -> Self {
+        self.style.box_color = color;
+        self
+    }
     pub fn with_border_weight(mut self, border_weight: f64) -> Self {
         self.style.border_weight = border_weight;
         self

--- a/libwaysip/src/state.rs
+++ b/libwaysip/src/state.rs
@@ -334,6 +334,7 @@ impl WaysipState {
                 *start_position,
                 *size,
                 self.is_area(),
+                self.predefined_boxes.as_ref(),
             );
         }
     }

--- a/libwaysip/src/state.rs
+++ b/libwaysip/src/state.rs
@@ -18,6 +18,7 @@ use wayland_protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1::ZwlrL
 
 use crate::{
     Position, Size, Style,
+    error::BoxInfoError,
     render::{self, UiInit},
 };
 
@@ -29,6 +30,7 @@ pub enum SelectionType {
     Area,
     Point,
     Screen,
+    PredefinedBoxes,
 }
 
 #[derive(Debug, Clone)]
@@ -175,6 +177,7 @@ pub struct WaysipState {
     pub cursor_manager: Option<WpCursorShapeManagerV1>,
     pub shm: Option<WlShm>,
     pub qh: Option<QueueHandle<Self>>,
+    pub predefined_boxes: Option<Vec<BoxInfo>>,
     pub last_redraw: std::time::Instant,
 }
 
@@ -192,6 +195,7 @@ impl WaysipState {
             cursor_manager: None,
             qh: None,
             shm: None,
+            predefined_boxes: None,
             last_redraw: std::time::Instant::now() - std::time::Duration::from_secs(1),
         }
     }
@@ -202,6 +206,14 @@ impl WaysipState {
 
     pub fn is_screen(&self) -> bool {
         matches!(self.selection_type, SelectionType::Screen)
+    }
+
+    pub fn is_predefined_boxes(&self) -> bool {
+        matches!(self.selection_type, SelectionType::PredefinedBoxes)
+    }
+
+    pub fn set_boxes(&mut self, boxes: Vec<BoxInfo>) {
+        self.predefined_boxes = Some(boxes);
     }
 
     pub fn ensure_buffer(&mut self, surface: &ZwlrLayerSurfaceV1, (width, height): (u32, u32)) {
@@ -316,9 +328,10 @@ impl WaysipState {
             }
             info.redraw(
                 self.start_pos.unwrap(),
-                self.current_pos,
+                self.end_pos,
                 *start_position,
                 *size,
+                self.is_area(),
             );
         }
     }
@@ -334,10 +347,12 @@ impl WaysipState {
         let Position { x: end_x, y: end_y } = self.end_pos.unwrap();
         let output = self.wloutput_infos[self.current_screen].clone();
         Some(AreaInfo {
-            start_x,
-            start_y,
-            end_x,
-            end_y,
+            box_info: BoxInfo {
+                start_x,
+                start_y,
+                end_x,
+                end_y,
+            },
             screen_info: output.get_screen_info(),
         })
     }
@@ -360,21 +375,58 @@ pub struct LayerSurfaceInfo {
     pub font_desc_normal: std::cell::OnceCell<pango::FontDescription>,
 }
 
-/// describe the information of the area
+/// coodrinates of box
 #[derive(Debug)]
-pub struct AreaInfo {
+pub struct BoxInfo {
     pub start_x: f64,
     pub start_y: f64,
     pub end_x: f64,
     pub end_y: f64,
+}
 
+impl BoxInfo {
+    pub fn get_box_from_str(box_string: &str) -> Result<Self, BoxInfoError> {
+        let (coords, size) = box_string
+            .split_once(' ')
+            .ok_or(BoxInfoError::InvalidBoxString(box_string.to_string()))?;
+        let (start_x, start_y) = coords
+            .split_once(',')
+            .ok_or(BoxInfoError::InvalidBoxCoordsString(coords.to_string()))?;
+        let (width, height) = size
+            .split_once('x')
+            .ok_or(BoxInfoError::InvalidBoxSizeString(size.to_string()))?;
+        let start_x = start_x
+            .parse::<f64>()
+            .map_err(BoxInfoError::ParseFloatError)?;
+        let start_y = start_y
+            .parse::<f64>()
+            .map_err(BoxInfoError::ParseFloatError)?;
+        let width = width
+            .parse::<f64>()
+            .map_err(BoxInfoError::ParseFloatError)?;
+        let height = height
+            .parse::<f64>()
+            .map_err(BoxInfoError::ParseFloatError)?;
+        Ok(BoxInfo {
+            start_x,
+            start_y,
+            end_x: start_x + width,
+            end_y: start_y + height,
+        })
+    }
+}
+
+/// describe the information of the area
+#[derive(Debug)]
+pub struct AreaInfo {
+    pub box_info: BoxInfo,
     pub screen_info: ScreenInfo,
 }
 
 impl AreaInfo {
     /// provide the width of the area as f64
     pub fn width_f64(&self) -> f64 {
-        (self.end_x - self.start_x).abs()
+        (self.box_info.end_x - self.box_info.start_x).abs()
     }
 
     pub fn size(&self) -> Size {
@@ -398,7 +450,7 @@ impl AreaInfo {
 
     /// provide the height of the area as f64
     pub fn height_f64(&self) -> f64 {
-        (self.end_y - self.start_y).abs()
+        (self.box_info.end_y - self.box_info.start_y).abs()
     }
 
     /// provide the width of the area as i32
@@ -409,8 +461,8 @@ impl AreaInfo {
     /// calculate the real start position
     pub fn left_top_point(&self) -> Position {
         Position {
-            x: self.start_x.min(self.end_x) as i32,
-            y: (self.start_y.min(self.end_y)) as i32,
+            x: self.box_info.start_x.min(self.box_info.end_x) as i32,
+            y: (self.box_info.start_y.min(self.box_info.end_y)) as i32,
         }
     }
 

--- a/libwaysip/src/state.rs
+++ b/libwaysip/src/state.rs
@@ -375,7 +375,7 @@ pub struct LayerSurfaceInfo {
     pub font_desc_normal: std::cell::OnceCell<pango::FontDescription>,
 }
 
-/// coodrinates of box
+/// coordinates of box
 #[derive(Debug)]
 pub struct BoxInfo {
     pub start_x: f64,

--- a/libwaysip/src/state.rs
+++ b/libwaysip/src/state.rs
@@ -178,6 +178,7 @@ pub struct WaysipState {
     pub shm: Option<WlShm>,
     pub qh: Option<QueueHandle<Self>>,
     pub predefined_boxes: Option<Vec<BoxInfo>>,
+    pub aspect_ratio: Option<(f64, f64)>,
     pub last_redraw: std::time::Instant,
 }
 
@@ -196,6 +197,7 @@ impl WaysipState {
             qh: None,
             shm: None,
             predefined_boxes: None,
+            aspect_ratio: None,
             last_redraw: std::time::Instant::now() - std::time::Duration::from_secs(1),
         }
     }

--- a/libwaysip/src/utils.rs
+++ b/libwaysip/src/utils.rs
@@ -69,6 +69,7 @@ pub struct Style {
     pub background_color: Color,
     pub foreground_color: Color,
     pub border_text_color: Color,
+    pub box_color: Color,
     pub border_weight: f64,
     pub font_size: i32,
     pub font_name: String,
@@ -95,6 +96,12 @@ impl Default for Style {
                 b: 0.0,
                 a: 1.0,
             }, // #000000ff
+            box_color: Color {
+                r: 0.4,
+                g: 0.4,
+                b: 0.4,
+                a: 0.5,
+            }, // #66666680
             border_weight: 1.0,
             font_size: 12,
             font_name: "Sans".to_string(),

--- a/waysip/Cargo.toml
+++ b/waysip/Cargo.toml
@@ -16,3 +16,4 @@ clap = { version = "4.5.40", features = ["derive"] }
 libwaysip.workspace = true
 tracing.workspace = true
 tracing-subscriber = "0.3"
+atty = "0.2"

--- a/waysip/src/main.rs
+++ b/waysip/src/main.rs
@@ -24,7 +24,7 @@ struct Args {
     #[arg(short = 'B', value_name = "#rrggbbaa/rrggbbaa")]
     box_color: Option<String>,
 
-    /// Set border weight.
+    /// Set the font family for the dimensions.
     #[arg(short = 'F', value_name = "string")]
     font_name: Option<String>,
 

--- a/waysip/src/main.rs
+++ b/waysip/src/main.rs
@@ -20,11 +20,15 @@ struct Args {
     #[arg(short = 's', value_name = "#rrggbbaa/rrggbbaa")]
     selection_color: Option<String>,
 
+    /// Set option box color.
+    #[arg(short = 'B', value_name = "#rrggbbaa/rrggbbaa")]
+    box_color: Option<String>,
+
     /// Set border weight.
     #[arg(short = 'F', value_name = "string")]
     font_name: Option<String>,
 
-    /// Set fomt size.
+    /// Set font size.
     #[arg(short = 'S', value_name = "integer")]
     font_size: Option<i32>,
 
@@ -88,6 +92,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     eprintln!("Err: {e}");
                     std::process::exit(1);
                 }));
+        }
+        if let Some(color) = args.box_color.take() {
+            builder = builder.with_box_color(Color::hex_to_color(color).unwrap_or_else(|e| {
+                eprintln!("Err: {e}");
+                std::process::exit(1);
+            }));
         }
         if let Some(border_weight) = args.border_weight.take() {
             let bw = border_weight.parse::<f64>().unwrap_or_else(|_| {

--- a/waysip/src/main.rs
+++ b/waysip/src/main.rs
@@ -51,6 +51,10 @@ struct Args {
     /// Restrict selection to predefined boxes.
     #[arg(short = 'r', conflicts_with_all = ["point", "dimensions", "output" , "screen"])]
     boxes: bool,
+
+    /// Force aspect ratio.
+    #[arg(short = 'a', value_name = "width:height", conflicts_with_all = ["point", "screen", "output", "boxes"])]
+    aspect_ratio: Option<String>,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -100,6 +104,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         if let Some(boxes) = boxes {
             builder = builder.with_predefined_boxes(boxes);
+        }
+        if let Some(aspect_ratio) = args.aspect_ratio.take() {
+            let parts: Vec<&str> = aspect_ratio.split(':').collect();
+            if parts.len() != 2 {
+                eprintln!("Invalid aspect ratio format, use -a <width:height>");
+                std::process::exit(1);
+            }
+            let width = parts[0].parse::<f64>().unwrap_or_else(|_| {
+                eprintln!("Invalid width in aspect ratio");
+                std::process::exit(1);
+            });
+            let height = parts[1].parse::<f64>().unwrap_or_else(|_| {
+                eprintln!("Invalid height in aspect ratio");
+                std::process::exit(1);
+            });
+            builder = builder.with_aspect_ratio(width, height);
         }
 
         match builder.get() {


### PR DESCRIPTION
What's done:
* Implement -r flag, restrict selection to predefined boxes.
* Change timeout for -d flag(found 8ms most optimal value) .
* Change position of second line of text for -o flag as font now is not static.
* Add plate for text in -o flag for better readability.
* Draw text for -o flag only on active display, otherwise it's confusing as other displays are also signed as active one.
* Implement -a flag, aspect ratio support.
* Add last color with -B flag for option boxes.

ps.
Would like to add some [nix changes](https://github.com/waycrate/waysip/commit/bc2ec0744145e87e1f302d24bb77d5fbd8e5ff3d), should I create separate pr or just commit here?


