### PR TITLE
feature: add benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /result
 flamegraph*
 perf.data*
+NOTES*.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,5 @@ keywords = ["wayland", "wlroots", "slurp"]
 readme = "README.md"
 
 [workspace.dependencies]
+libwaysip = { version = "0.6.1", path = "./libwaysip", default-features = false }
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,4 @@ keywords = ["wayland", "wlroots", "slurp"]
 readme = "README.md"
 
 [workspace.dependencies]
-libwaysip = { version = "0.6.1", path = "./libwaysip" }
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -71,18 +71,21 @@ waysip --completions nushell | save -f ~/.config/nushell/completions/waysip.nu
 
 # Optional features
 
-All features are enabled in the default build. To reduce binary size or compile-time dependencies, features can be selectively disabled:
+All features except `benchmark` are enabled in the default build. To reduce binary size or compile-time dependencies, features can be selectively disabled:
 
 ```bash
+cargo build --no-default-features --features frame-limiter
 cargo build --no-default-features --features logger
 cargo build --no-default-features --features completions
-cargo build --no-default-features --features logger,completions
+cargo build --no-default-features --features frame-limit,logger,completions
 ```
 
 | Feature       | What it adds                                               | Extra dependency          |
 | ------------- | ---------------------------------------------------------- | ------------------------- |
+| `frame-limit` | Workaround to fix frametime issue on low frequency CPUs    | None                      |
 | `logger`      | `--log-level` flag, tracing output to stderr               | tracing-subscriber        |
 | `completions` | `--completions <SHELL>`, generate shell completion scripts | clap_complete (+ nushell) |
+| `benchmark`   | Benchmarking options for development described [here](#development-benchmarking)| None |
 
 # Installation
 
@@ -115,6 +118,33 @@ nix build github:waycrate/waysip
 ```bash
 nix run github:waycrate/waysip
 ```
+
+# Development benchmarking
+
+To enable benchmarking options use one of those options depending on usecase described later:
+```bash
+cargo build --no-default-features --features "logger completions benchmark"
+cargo build --no-default-features --features "logger completions frame-limit benchmark"
+```
+
+Regarding `frame-limit` feature. It is a workaround enabled by default meant to solve issue with unstable frametime on low freq CPUs or under heavy load.
+
+## Benchmark usage
+
+### `--bench`
+
+Records each `wl_callback.done` timestamp from the compositor for the focused screen (duplicate timestamps are dropped, so it's roughly one entry per frame) and prints frame stats on stderr when the selection ends.
+
+Reported metrics (written to stderr):
+- `fps avg`
+- `frametime: min / avg / max`
+- `latencies` - array of entries meant track where frametime issues happened
+
+For drag modes the `raw duration` and the amount trimmed from each end are also printed.
+For non-drag options less frames-better.
+
+To test frametime stability try lowering your cpu freq to 0.8 GHz and build without frame-limit feature before testing.
+
 
 # Support:
 

--- a/libwaysip/Cargo.toml
+++ b/libwaysip/Cargo.toml
@@ -9,6 +9,10 @@ repository.workspace = true
 keywords.workspace = true
 readme.workspace = true
 
+[features]
+default = ["frame-limit"]
+frame-limit = []
+
 [dependencies]
 tempfile = "3.27"
 wayland-client = "0.31"

--- a/libwaysip/Cargo.toml
+++ b/libwaysip/Cargo.toml
@@ -12,6 +12,7 @@ readme.workspace = true
 [features]
 default = ["frame-limit"]
 frame-limit = []
+benchmark = []
 
 [dependencies]
 tempfile = "3.27"

--- a/libwaysip/src/dispatch.rs
+++ b/libwaysip/src/dispatch.rs
@@ -224,6 +224,12 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                             dispatch_state.mouse_press_time = Some(std::time::Instant::now());
                         }
 
+                        #[cfg(feature = "benchmark")]
+                        if dispatch_state.benchmark {
+                            dispatch_state.bench_start = std::time::Instant::now();
+                            dispatch_state.frames_per_second.clear();
+                        }
+
                         if !dispatch_state.is_predefined_boxes() {
                             dispatch_state.set_start_pos(dispatch_state.current_pos);
                         }
@@ -288,7 +294,7 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                     }
                     _ => {}
                 }
-                dispatch_state.commit();
+                dispatch_state.try_commit();
             }
             wl_pointer::Event::Enter {
                 serial,
@@ -339,7 +345,7 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                     cursor_surface.commit();
                 }
 
-                dispatch_state.commit();
+                dispatch_state.try_commit();
             }
             wl_pointer::Event::Motion {
                 surface_x,
@@ -382,19 +388,12 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                     } else {
                         dispatch_state.end_pos = Some(dispatch_state.current_pos);
                     }
-
                     #[cfg(feature = "frame-limit")]
                     {
-                        let now = std::time::Instant::now();
-                        if now.duration_since(dispatch_state.last_redraw)
-                            >= std::time::Duration::from_millis(8)
-                        {
-                            dispatch_state.commit();
-                            dispatch_state.last_redraw = now;
-                        }
+                        dispatch_state.try_commit();
                     }
                     #[cfg(not(feature = "frame-limit"))]
-                    dispatch_state.commit();
+                    dispatch_state.try_commit();
                 } else if dispatch_state.is_predefined_boxes() {
                     let current_pos = dispatch_state.current_pos;
                     if let Some(box_info) = dispatch_state
@@ -421,17 +420,10 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                     }
                     #[cfg(feature = "frame-limit")]
                     {
-                        let now = std::time::Instant::now();
-                        if now.duration_since(dispatch_state.last_redraw)
-                            >= std::time::Duration::from_millis(20)
-                        // no need to redraw faster as boxes are not moving
-                        {
-                            dispatch_state.commit();
-                            dispatch_state.last_redraw = now;
-                        }
+                        dispatch_state.try_commit();
                     }
                     #[cfg(not(feature = "frame-limit"))]
-                    dispatch_state.commit();
+                    dispatch_state.try_commit();
                 }
             }
             _ => {}

--- a/libwaysip/src/dispatch.rs
+++ b/libwaysip/src/dispatch.rs
@@ -225,7 +225,10 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                         }
 
                         #[cfg(feature = "benchmark")]
-                        if dispatch_state.benchmark {
+                        if dispatch_state.benchmark
+                            && (dispatch_state.is_area()
+                                || dispatch_state.is_dimensions_or_output())
+                        {
                             dispatch_state.bench_start = std::time::Instant::now();
                             dispatch_state.frames_per_second.clear();
                         }

--- a/libwaysip/src/dispatch.rs
+++ b/libwaysip/src/dispatch.rs
@@ -225,12 +225,12 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                         }
 
                         #[cfg(feature = "benchmark")]
-                        if dispatch_state.benchmark
+                        if dispatch_state.bench_fn
                             && (dispatch_state.is_area()
                                 || dispatch_state.is_dimensions_or_output())
                         {
                             dispatch_state.bench_start = std::time::Instant::now();
-                            dispatch_state.frames_per_second.clear();
+                            dispatch_state.timestamps_fn.clear();
                         }
 
                         if !dispatch_state.is_predefined_boxes() {
@@ -391,11 +391,6 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                     } else {
                         dispatch_state.end_pos = Some(dispatch_state.current_pos);
                     }
-                    #[cfg(feature = "frame-limit")]
-                    {
-                        dispatch_state.try_commit();
-                    }
-                    #[cfg(not(feature = "frame-limit"))]
                     dispatch_state.try_commit();
                 } else if dispatch_state.is_predefined_boxes() {
                     let current_pos = dispatch_state.current_pos;
@@ -421,11 +416,6 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                             y: box_info.end_y,
                         });
                     }
-                    #[cfg(feature = "frame-limit")]
-                    {
-                        dispatch_state.try_commit();
-                    }
-                    #[cfg(not(feature = "frame-limit"))]
                     dispatch_state.try_commit();
                 }
             }
@@ -443,9 +433,16 @@ impl Dispatch<WlCallback, usize> for state::WaysipState {
         _conn: &Connection,
         _qhandle: &wayland_client::QueueHandle<Self>,
     ) {
-        if let wl_callback::Event::Done { .. } = event {
+        if let wl_callback::Event::Done {
+            callback_data: _callback_data,
+        } = event
+        {
             if *screen_index != state.current_screen {
                 return;
+            }
+            #[cfg(feature = "benchmark")]
+            if state.bench_total {
+                state.timestamps_total.push(_callback_data);
             }
             state.redraw();
         }

--- a/libwaysip/src/dispatch.rs
+++ b/libwaysip/src/dispatch.rs
@@ -383,13 +383,18 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                         dispatch_state.end_pos = Some(dispatch_state.current_pos);
                     }
 
-                    let now = std::time::Instant::now();
-                    if now.duration_since(dispatch_state.last_redraw)
-                        >= std::time::Duration::from_millis(8)
+                    #[cfg(feature = "frame-limit")]
                     {
-                        dispatch_state.commit();
-                        dispatch_state.last_redraw = now;
+                        let now = std::time::Instant::now();
+                        if now.duration_since(dispatch_state.last_redraw)
+                            >= std::time::Duration::from_millis(8)
+                        {
+                            dispatch_state.commit();
+                            dispatch_state.last_redraw = now;
+                        }
                     }
+                    #[cfg(not(feature = "frame-limit"))]
+                    dispatch_state.commit();
                 } else if dispatch_state.is_predefined_boxes() {
                     let current_pos = dispatch_state.current_pos;
                     if let Some(box_info) = dispatch_state
@@ -414,14 +419,19 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                             y: box_info.end_y,
                         });
                     }
-                    let now = std::time::Instant::now();
-                    if now.duration_since(dispatch_state.last_redraw)
-                        >= std::time::Duration::from_millis(20)
-                    // no need to redraw faster as boxes are not moving
+                    #[cfg(feature = "frame-limit")]
                     {
-                        dispatch_state.commit();
-                        dispatch_state.last_redraw = now;
+                        let now = std::time::Instant::now();
+                        if now.duration_since(dispatch_state.last_redraw)
+                            >= std::time::Duration::from_millis(20)
+                        // no need to redraw faster as boxes are not moving
+                        {
+                            dispatch_state.commit();
+                            dispatch_state.last_redraw = now;
+                        }
                     }
+                    #[cfg(not(feature = "frame-limit"))]
+                    dispatch_state.commit();
                 }
             }
             _ => {}

--- a/libwaysip/src/dispatch.rs
+++ b/libwaysip/src/dispatch.rs
@@ -225,12 +225,11 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                         }
 
                         #[cfg(feature = "benchmark")]
-                        if dispatch_state.bench_fn
+                        if dispatch_state.bench
                             && (dispatch_state.is_area()
                                 || dispatch_state.is_dimensions_or_output())
                         {
-                            dispatch_state.bench_start = std::time::Instant::now();
-                            dispatch_state.timestamps_fn.clear();
+                            dispatch_state.timestamps_total.clear();
                         }
 
                         if !dispatch_state.is_predefined_boxes() {
@@ -440,8 +439,9 @@ impl Dispatch<WlCallback, usize> for state::WaysipState {
             if *screen_index != state.current_screen {
                 return;
             }
+
             #[cfg(feature = "benchmark")]
-            if state.bench_total {
+            if state.bench && state.timestamps_total.last().copied() != Some(_callback_data) {
                 state.timestamps_total.push(_callback_data);
             }
             state.redraw();

--- a/libwaysip/src/lib.rs
+++ b/libwaysip/src/lib.rs
@@ -46,7 +46,9 @@ pub struct WaySip {
     predefined_boxes: Option<Vec<state::BoxInfo>>,
     aspect_ratio: Option<(f64, f64)>,
     #[cfg(feature = "benchmark")]
-    benchmark: bool,
+    bench_fn: bool,
+    #[cfg(feature = "benchmark")]
+    bench_total: bool,
 }
 
 impl WaySip {
@@ -106,15 +108,21 @@ impl WaySip {
     }
 
     #[cfg(feature = "benchmark")]
-    pub fn with_benchmark(mut self) -> Self {
-        self.benchmark = true;
+    pub fn with_bench_fn(mut self) -> Self {
+        self.bench_fn = true;
+        self
+    }
+
+    #[cfg(feature = "benchmark")]
+    pub fn with_bench_total(mut self) -> Self {
+        self.bench_total = true;
         self
     }
 
     /// get the selected area
     pub fn get(self) -> Result<Option<state::AreaInfo>, WaySipError> {
         #[cfg(feature = "benchmark")]
-        let benchmark = self.benchmark;
+        let (bench_fn, bench_total) = (self.bench_fn, self.bench_total);
 
         match self.conn {
             Some(connection) => get_area_inner(
@@ -124,7 +132,9 @@ impl WaySip {
                 self.predefined_boxes,
                 self.aspect_ratio,
                 #[cfg(feature = "benchmark")]
-                benchmark,
+                bench_fn,
+                #[cfg(feature = "benchmark")]
+                bench_total,
             ),
             None => {
                 let connection = Connection::connect_to_env()
@@ -137,7 +147,9 @@ impl WaySip {
                     self.predefined_boxes,
                     self.aspect_ratio,
                     #[cfg(feature = "benchmark")]
-                    benchmark,
+                    bench_fn,
+                    #[cfg(feature = "benchmark")]
+                    bench_total,
                 )
             }
         }
@@ -150,7 +162,8 @@ fn get_area_inner(
     style: Style,
     boxes: Option<Vec<state::BoxInfo>>,
     aspect_ratio: Option<(f64, f64)>,
-    #[cfg(feature = "benchmark")] benchmark: bool,
+    #[cfg(feature = "benchmark")] bench_fn: bool,
+    #[cfg(feature = "benchmark")] bench_total: bool,
 ) -> Result<Option<state::AreaInfo>, WaySipError> {
     let (globals, _) = registry_queue_init::<state::WaysipState>(connection)
         .map_err(|e| WaySipError::InitFailed(e.to_string()))?;
@@ -283,11 +296,12 @@ fn get_area_inner(
 
     #[cfg(feature = "benchmark")]
     {
-        state.benchmark = benchmark;
+        state.bench_fn = bench_fn;
+        state.bench_total = bench_total;
     }
 
     #[cfg(feature = "benchmark")]
-    if state.benchmark {
+    if state.bench_fn {
         let mut did_commit = false;
         while state.running {
             event_queue

--- a/libwaysip/src/lib.rs
+++ b/libwaysip/src/lib.rs
@@ -45,6 +45,8 @@ pub struct WaySip {
     style: Style,
     predefined_boxes: Option<Vec<state::BoxInfo>>,
     aspect_ratio: Option<(f64, f64)>,
+    #[cfg(feature = "benchmark")]
+    benchmark: bool,
 }
 
 impl WaySip {
@@ -103,8 +105,17 @@ impl WaySip {
         self
     }
 
+    #[cfg(feature = "benchmark")]
+    pub fn with_benchmark(mut self) -> Self {
+        self.benchmark = true;
+        self
+    }
+
     /// get the selected area
     pub fn get(self) -> Result<Option<state::AreaInfo>, WaySipError> {
+        #[cfg(feature = "benchmark")]
+        let benchmark = self.benchmark;
+
         match self.conn {
             Some(connection) => get_area_inner(
                 &connection,
@@ -112,6 +123,8 @@ impl WaySip {
                 self.style,
                 self.predefined_boxes,
                 self.aspect_ratio,
+                #[cfg(feature = "benchmark")]
+                benchmark,
             ),
             None => {
                 let connection = Connection::connect_to_env()
@@ -123,6 +136,8 @@ impl WaySip {
                     self.style,
                     self.predefined_boxes,
                     self.aspect_ratio,
+                    #[cfg(feature = "benchmark")]
+                    benchmark,
                 )
             }
         }
@@ -135,6 +150,7 @@ fn get_area_inner(
     style: Style,
     boxes: Option<Vec<state::BoxInfo>>,
     aspect_ratio: Option<(f64, f64)>,
+    #[cfg(feature = "benchmark")] benchmark: bool,
 ) -> Result<Option<state::AreaInfo>, WaySipError> {
     let (globals, _) = registry_queue_init::<state::WaysipState>(connection)
         .map_err(|e| WaySipError::InitFailed(e.to_string()))?;
@@ -263,8 +279,33 @@ fn get_area_inner(
         });
     }
     state.shm = Some(shm);
-
     state.qh = Some(qh);
+
+    #[cfg(feature = "benchmark")]
+    {
+        state.benchmark = benchmark;
+    }
+
+    #[cfg(feature = "benchmark")]
+    if state.benchmark {
+        let mut did_commit = false;
+        while state.running {
+            event_queue
+                .blocking_dispatch(&mut state)
+                .map_err(WaySipError::DispatchError)?;
+            if did_commit {
+                state.record_frame();
+            }
+            did_commit = state.try_commit();
+        }
+    } else {
+        while state.running {
+            event_queue
+                .blocking_dispatch(&mut state)
+                .map_err(WaySipError::DispatchError)?;
+        }
+    }
+    #[cfg(not(feature = "benchmark"))]
     while state.running {
         event_queue
             .blocking_dispatch(&mut state)

--- a/libwaysip/src/lib.rs
+++ b/libwaysip/src/lib.rs
@@ -293,7 +293,8 @@ fn get_area_inner(
             event_queue
                 .blocking_dispatch(&mut state)
                 .map_err(WaySipError::DispatchError)?;
-            if did_commit {
+            let needs_drag = state.is_area() || state.is_dimensions_or_output();
+            if did_commit && (!needs_drag || state.start_pos.is_some()) {
                 state.record_frame();
             }
             did_commit = state.try_commit();

--- a/libwaysip/src/lib.rs
+++ b/libwaysip/src/lib.rs
@@ -46,9 +46,7 @@ pub struct WaySip {
     predefined_boxes: Option<Vec<state::BoxInfo>>,
     aspect_ratio: Option<(f64, f64)>,
     #[cfg(feature = "benchmark")]
-    bench_fn: bool,
-    #[cfg(feature = "benchmark")]
-    bench_total: bool,
+    bench: bool,
 }
 
 impl WaySip {
@@ -108,21 +106,15 @@ impl WaySip {
     }
 
     #[cfg(feature = "benchmark")]
-    pub fn with_bench_fn(mut self) -> Self {
-        self.bench_fn = true;
-        self
-    }
-
-    #[cfg(feature = "benchmark")]
-    pub fn with_bench_total(mut self) -> Self {
-        self.bench_total = true;
+    pub fn with_bench(mut self) -> Self {
+        self.bench = true;
         self
     }
 
     /// get the selected area
     pub fn get(self) -> Result<Option<state::AreaInfo>, WaySipError> {
         #[cfg(feature = "benchmark")]
-        let (bench_fn, bench_total) = (self.bench_fn, self.bench_total);
+        let bench = self.bench;
 
         match self.conn {
             Some(connection) => get_area_inner(
@@ -132,9 +124,7 @@ impl WaySip {
                 self.predefined_boxes,
                 self.aspect_ratio,
                 #[cfg(feature = "benchmark")]
-                bench_fn,
-                #[cfg(feature = "benchmark")]
-                bench_total,
+                bench,
             ),
             None => {
                 let connection = Connection::connect_to_env()
@@ -147,9 +137,7 @@ impl WaySip {
                     self.predefined_boxes,
                     self.aspect_ratio,
                     #[cfg(feature = "benchmark")]
-                    bench_fn,
-                    #[cfg(feature = "benchmark")]
-                    bench_total,
+                    bench,
                 )
             }
         }
@@ -162,8 +150,7 @@ fn get_area_inner(
     style: Style,
     boxes: Option<Vec<state::BoxInfo>>,
     aspect_ratio: Option<(f64, f64)>,
-    #[cfg(feature = "benchmark")] bench_fn: bool,
-    #[cfg(feature = "benchmark")] bench_total: bool,
+    #[cfg(feature = "benchmark")] bench: bool,
 ) -> Result<Option<state::AreaInfo>, WaySipError> {
     let (globals, _) = registry_queue_init::<state::WaysipState>(connection)
         .map_err(|e| WaySipError::InitFailed(e.to_string()))?;
@@ -296,31 +283,9 @@ fn get_area_inner(
 
     #[cfg(feature = "benchmark")]
     {
-        state.bench_fn = bench_fn;
-        state.bench_total = bench_total;
+        state.bench = bench;
     }
 
-    #[cfg(feature = "benchmark")]
-    if state.bench_fn {
-        let mut did_commit = false;
-        while state.running {
-            event_queue
-                .blocking_dispatch(&mut state)
-                .map_err(WaySipError::DispatchError)?;
-            let needs_drag = state.is_area() || state.is_dimensions_or_output();
-            if did_commit && (!needs_drag || state.start_pos.is_some()) {
-                state.record_frame();
-            }
-            did_commit = state.try_commit();
-        }
-    } else {
-        while state.running {
-            event_queue
-                .blocking_dispatch(&mut state)
-                .map_err(WaySipError::DispatchError)?;
-        }
-    }
-    #[cfg(not(feature = "benchmark"))]
     while state.running {
         event_queue
             .blocking_dispatch(&mut state)

--- a/libwaysip/src/state.rs
+++ b/libwaysip/src/state.rs
@@ -183,6 +183,12 @@ pub struct WaysipState {
     pub(crate) aspect_ratio: Option<(f64, f64)>,
     #[cfg(feature = "frame-limit")]
     pub(crate) last_redraw: std::time::Instant,
+    #[cfg(feature = "benchmark")]
+    pub(crate) benchmark: bool,
+    #[cfg(feature = "benchmark")]
+    pub(crate) bench_start: std::time::Instant,
+    #[cfg(feature = "benchmark")]
+    pub(crate) frames_per_second: Vec<u32>,
     /// Tracks actual effective selection type for DimensionsOrOutput mode
     pub(crate) effective_selection_type: Option<SelectionType>,
     /// Time when mouse was pressed down
@@ -208,6 +214,12 @@ impl WaysipState {
             aspect_ratio: None,
             #[cfg(feature = "frame-limit")]
             last_redraw: std::time::Instant::now() - std::time::Duration::from_secs(1),
+            #[cfg(feature = "benchmark")]
+            benchmark: false,
+            #[cfg(feature = "benchmark")]
+            bench_start: std::time::Instant::now(),
+            #[cfg(feature = "benchmark")]
+            frames_per_second: Vec::new(),
             effective_selection_type: None,
             mouse_press_time: None,
             redraw_all: false,
@@ -323,6 +335,35 @@ impl WaysipState {
         }
     }
 
+    #[cfg(feature = "benchmark")]
+    pub(crate) fn try_commit(&mut self) -> bool {
+        #[cfg(feature = "frame-limit")]
+        {
+            let now = std::time::Instant::now();
+            if now.duration_since(self.last_redraw) >= std::time::Duration::from_millis(8) {
+                self.commit();
+                self.last_redraw = now;
+                return true;
+            }
+            return false;
+        }
+
+        #[cfg(not(feature = "frame-limit"))]
+        {
+            self.commit();
+            return true;
+        }
+    }
+
+    #[cfg(feature = "benchmark")]
+    pub(crate) fn record_frame(&mut self) {
+        let elapsed = self.bench_start.elapsed().as_secs() as usize;
+        if elapsed >= self.frames_per_second.len() {
+            self.frames_per_second.resize(elapsed + 1, 0);
+        }
+        self.frames_per_second[elapsed] += 1;
+    }
+
     /// redraw all surface
     pub fn redraw(&mut self) {
         for i in 0..self.wl_surfaces.len() {
@@ -410,6 +451,8 @@ impl WaysipState {
             },
             screen_info: output.get_screen_info(),
             effective_selection_type: self.effective_selection_type,
+            #[cfg(feature = "benchmark")]
+            frames_per_second: self.frames_per_second.clone(),
         })
     }
 }
@@ -481,6 +524,8 @@ pub struct AreaInfo {
     pub box_info: BoxInfo,
     pub screen_info: ScreenInfo,
     pub effective_selection_type: Option<SelectionType>,
+    #[cfg(feature = "benchmark")]
+    pub frames_per_second: Vec<u32>,
 }
 
 impl AreaInfo {

--- a/libwaysip/src/state.rs
+++ b/libwaysip/src/state.rs
@@ -335,7 +335,6 @@ impl WaysipState {
         }
     }
 
-    #[cfg(feature = "benchmark")]
     pub(crate) fn try_commit(&mut self) -> bool {
         #[cfg(feature = "frame-limit")]
         {
@@ -345,13 +344,13 @@ impl WaysipState {
                 self.last_redraw = now;
                 return true;
             }
-            return false;
+            false
         }
 
         #[cfg(not(feature = "frame-limit"))]
         {
             self.commit();
-            return true;
+            true
         }
     }
 

--- a/libwaysip/src/state.rs
+++ b/libwaysip/src/state.rs
@@ -181,6 +181,7 @@ pub struct WaysipState {
     pub(crate) qh: Option<QueueHandle<Self>>,
     pub(crate) predefined_boxes: Option<Vec<BoxInfo>>,
     pub(crate) aspect_ratio: Option<(f64, f64)>,
+    #[cfg(feature = "frame-limit")]
     pub(crate) last_redraw: std::time::Instant,
     /// Tracks actual effective selection type for DimensionsOrOutput mode
     pub(crate) effective_selection_type: Option<SelectionType>,
@@ -205,6 +206,7 @@ impl WaysipState {
             shm: None,
             predefined_boxes: None,
             aspect_ratio: None,
+            #[cfg(feature = "frame-limit")]
             last_redraw: std::time::Instant::now() - std::time::Duration::from_secs(1),
             effective_selection_type: None,
             mouse_press_time: None,

--- a/libwaysip/src/state.rs
+++ b/libwaysip/src/state.rs
@@ -184,11 +184,15 @@ pub struct WaysipState {
     #[cfg(feature = "frame-limit")]
     pub(crate) last_redraw: std::time::Instant,
     #[cfg(feature = "benchmark")]
-    pub(crate) benchmark: bool,
+    pub(crate) bench_fn: bool,
+    #[cfg(feature = "benchmark")]
+    pub(crate) bench_total: bool,
     #[cfg(feature = "benchmark")]
     pub(crate) bench_start: std::time::Instant,
     #[cfg(feature = "benchmark")]
-    pub(crate) frames_per_second: Vec<u32>,
+    pub(crate) timestamps_fn: Vec<u32>,
+    #[cfg(feature = "benchmark")]
+    pub(crate) timestamps_total: Vec<u32>,
     /// Tracks actual effective selection type for DimensionsOrOutput mode
     pub(crate) effective_selection_type: Option<SelectionType>,
     /// Time when mouse was pressed down
@@ -215,11 +219,15 @@ impl WaysipState {
             #[cfg(feature = "frame-limit")]
             last_redraw: std::time::Instant::now() - std::time::Duration::from_secs(1),
             #[cfg(feature = "benchmark")]
-            benchmark: false,
+            bench_fn: false,
+            #[cfg(feature = "benchmark")]
+            bench_total: false,
             #[cfg(feature = "benchmark")]
             bench_start: std::time::Instant::now(),
             #[cfg(feature = "benchmark")]
-            frames_per_second: Vec::new(),
+            timestamps_fn: Vec::new(),
+            #[cfg(feature = "benchmark")]
+            timestamps_total: Vec::new(),
             effective_selection_type: None,
             mouse_press_time: None,
             redraw_all: false,
@@ -356,11 +364,8 @@ impl WaysipState {
 
     #[cfg(feature = "benchmark")]
     pub(crate) fn record_frame(&mut self) {
-        let elapsed = self.bench_start.elapsed().as_secs() as usize;
-        if elapsed >= self.frames_per_second.len() {
-            self.frames_per_second.resize(elapsed + 1, 0);
-        }
-        self.frames_per_second[elapsed] += 1;
+        self.timestamps_fn
+            .push(self.bench_start.elapsed().as_millis() as u32);
     }
 
     /// redraw all surface
@@ -451,7 +456,9 @@ impl WaysipState {
             screen_info: output.get_screen_info(),
             effective_selection_type: self.effective_selection_type,
             #[cfg(feature = "benchmark")]
-            frames_per_second: self.frames_per_second.clone(),
+            timestamps_fn: self.timestamps_fn.clone(),
+            #[cfg(feature = "benchmark")]
+            timestamps_total: self.timestamps_total.clone(),
         })
     }
 }
@@ -524,7 +531,9 @@ pub struct AreaInfo {
     pub screen_info: ScreenInfo,
     pub effective_selection_type: Option<SelectionType>,
     #[cfg(feature = "benchmark")]
-    pub frames_per_second: Vec<u32>,
+    pub timestamps_fn: Vec<u32>,
+    #[cfg(feature = "benchmark")]
+    pub timestamps_total: Vec<u32>,
 }
 
 impl AreaInfo {

--- a/libwaysip/src/state.rs
+++ b/libwaysip/src/state.rs
@@ -184,13 +184,7 @@ pub struct WaysipState {
     #[cfg(feature = "frame-limit")]
     pub(crate) last_redraw: std::time::Instant,
     #[cfg(feature = "benchmark")]
-    pub(crate) bench_fn: bool,
-    #[cfg(feature = "benchmark")]
-    pub(crate) bench_total: bool,
-    #[cfg(feature = "benchmark")]
-    pub(crate) bench_start: std::time::Instant,
-    #[cfg(feature = "benchmark")]
-    pub(crate) timestamps_fn: Vec<u32>,
+    pub(crate) bench: bool,
     #[cfg(feature = "benchmark")]
     pub(crate) timestamps_total: Vec<u32>,
     /// Tracks actual effective selection type for DimensionsOrOutput mode
@@ -219,13 +213,7 @@ impl WaysipState {
             #[cfg(feature = "frame-limit")]
             last_redraw: std::time::Instant::now() - std::time::Duration::from_secs(1),
             #[cfg(feature = "benchmark")]
-            bench_fn: false,
-            #[cfg(feature = "benchmark")]
-            bench_total: false,
-            #[cfg(feature = "benchmark")]
-            bench_start: std::time::Instant::now(),
-            #[cfg(feature = "benchmark")]
-            timestamps_fn: Vec::new(),
+            bench: false,
             #[cfg(feature = "benchmark")]
             timestamps_total: Vec::new(),
             effective_selection_type: None,
@@ -362,12 +350,6 @@ impl WaysipState {
         }
     }
 
-    #[cfg(feature = "benchmark")]
-    pub(crate) fn record_frame(&mut self) {
-        self.timestamps_fn
-            .push(self.bench_start.elapsed().as_millis() as u32);
-    }
-
     /// redraw all surface
     pub fn redraw(&mut self) {
         for i in 0..self.wl_surfaces.len() {
@@ -456,8 +438,6 @@ impl WaysipState {
             screen_info: output.get_screen_info(),
             effective_selection_type: self.effective_selection_type,
             #[cfg(feature = "benchmark")]
-            timestamps_fn: self.timestamps_fn.clone(),
-            #[cfg(feature = "benchmark")]
             timestamps_total: self.timestamps_total.clone(),
         })
     }
@@ -530,8 +510,6 @@ pub struct AreaInfo {
     pub box_info: BoxInfo,
     pub screen_info: ScreenInfo,
     pub effective_selection_type: Option<SelectionType>,
-    #[cfg(feature = "benchmark")]
-    pub timestamps_fn: Vec<u32>,
     #[cfg(feature = "benchmark")]
     pub timestamps_total: Vec<u32>,
 }

--- a/waysip/Cargo.toml
+++ b/waysip/Cargo.toml
@@ -25,6 +25,6 @@ benchmark = ["libwaysip/benchmark"]
 clap = { version = "4.6", features = ["derive"] }
 clap_complete = { version = "4.6", optional = true }
 clap_complete_nushell = { version = "4.6", optional = true }
-libwaysip = { version = "0.6.1", path = "./../libwaysip", default-features = false }
+libwaysip.workspace = true
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", optional = true }

--- a/waysip/Cargo.toml
+++ b/waysip/Cargo.toml
@@ -12,17 +12,18 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["logger", "completions"]
+default = ["logger", "completions", "frame-limit"]
 # Initialises the tracing subscriber and exposes the `--log-level` CLI flag.
 # Disable to suppress all stderr log output entirely.
 logger = ["dep:tracing-subscriber"]
 # Adds `--completions <SHELL>` for generating shell completion scripts.
 completions = ["dep:clap_complete", "dep:clap_complete_nushell"]
+frame-limit = ["libwaysip/frame-limit"]
 
 [dependencies]
 clap = { version = "4.6", features = ["derive"] }
 clap_complete = { version = "4.6", optional = true }
 clap_complete_nushell = { version = "4.6", optional = true }
-libwaysip.workspace = true
+libwaysip = { version = "0.6.1", path = "./../libwaysip", default-features = false }
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", optional = true }

--- a/waysip/Cargo.toml
+++ b/waysip/Cargo.toml
@@ -19,6 +19,7 @@ logger = ["dep:tracing-subscriber"]
 # Adds `--completions <SHELL>` for generating shell completion scripts.
 completions = ["dep:clap_complete", "dep:clap_complete_nushell"]
 frame-limit = ["libwaysip/frame-limit"]
+benchmark = ["libwaysip/benchmark"]
 
 [dependencies]
 clap = { version = "4.6", features = ["derive"] }

--- a/waysip/src/cli.rs
+++ b/waysip/src/cli.rs
@@ -110,4 +110,9 @@ pub struct Cli {
     #[cfg(feature = "logger")]
     #[arg(long)]
     pub log_level: Option<Level>,
+
+    /// Use unconditional loop for rendering and report framerate data
+    #[cfg(feature = "benchmark")]
+    #[arg(long)]
+    pub bench: bool,
 }

--- a/waysip/src/cli.rs
+++ b/waysip/src/cli.rs
@@ -111,8 +111,13 @@ pub struct Cli {
     #[arg(long)]
     pub log_level: Option<Level>,
 
-    /// Use unconditional loop for rendering and report framerate data
+    /// Use unconditional loop for rendering and report framerate data.
     #[cfg(feature = "benchmark")]
     #[arg(long)]
-    pub bench: bool,
+    pub bench_fn: bool,
+
+    /// Count frames for regular render.
+    #[cfg(feature = "benchmark")]
+    #[arg(long)]
+    pub bench_total: bool,
 }

--- a/waysip/src/cli.rs
+++ b/waysip/src/cli.rs
@@ -111,13 +111,8 @@ pub struct Cli {
     #[arg(long)]
     pub log_level: Option<Level>,
 
-    /// Use unconditional loop for rendering and report framerate data.
-    #[cfg(feature = "benchmark")]
-    #[arg(long)]
-    pub bench_fn: bool,
-
     /// Count frames for regular render.
     #[cfg(feature = "benchmark")]
     #[arg(long)]
-    pub bench_total: bool,
+    pub bench: bool,
 }

--- a/waysip/src/main.rs
+++ b/waysip/src/main.rs
@@ -27,9 +27,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if args.boxes {
         let boxes = read_boxes_from_stdin();
         let info = run_selection(&mut args, SelectionType::PredefinedBoxes, Some(boxes));
+        #[cfg(feature = "benchmark")]
+        if args.bench {
+            print_bench_results(&info.frames_per_second);
+        }
         print!("{}", apply_format(&info, &fmt, false));
     } else if let Some(mode) = SelectionDispatch::from_cli(&args) {
         let info = run_selection(&mut args, mode.selection_type(), None);
+        #[cfg(feature = "benchmark")]
+        if args.bench {
+            print_bench_results(&info.frames_per_second);
+        }
         let use_screen_format = match mode {
             SelectionDispatch::DimensionsOrOutput => {
                 matches!(info.effective_selection_type, Some(SelectionType::Screen))
@@ -41,4 +49,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+#[cfg(feature = "benchmark")]
+fn print_bench_results(fps: &[u32]) {
+    if fps.len() < 5 {
+        eprintln!("benchmark: not enough data (selection lasted less than 5 seconds)");
+        return;
+    }
+    let trimmed = &fps[1..fps.len() - 1];
+    let total: u64 = trimmed.iter().map(|&f| f as u64).sum();
+    let avg = total as f64 / trimmed.len() as f64;
+    let min = *trimmed.iter().min().unwrap();
+    eprintln!("benchmark results (first and last second excluded):");
+    eprintln!("  total frames : {total}");
+    eprintln!("  avg fps      : {avg:.1}");
+    eprintln!("  min fps      : {min}");
 }

--- a/waysip/src/main.rs
+++ b/waysip/src/main.rs
@@ -28,15 +28,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let boxes = read_boxes_from_stdin();
         let info = run_selection(&mut args, SelectionType::PredefinedBoxes, Some(boxes));
         #[cfg(feature = "benchmark")]
-        if args.bench {
-            print_bench_results(&info.frames_per_second);
+        {
+            if args.bench_fn {
+                print_bench_results("--bench-fn", &info.timestamps_fn);
+            }
+            if args.bench_total {
+                print_bench_results("--bench-total", &info.timestamps_total);
+            }
         }
         print!("{}", apply_format(&info, &fmt, false));
     } else if let Some(mode) = SelectionDispatch::from_cli(&args) {
         let info = run_selection(&mut args, mode.selection_type(), None);
         #[cfg(feature = "benchmark")]
-        if args.bench {
-            print_bench_results(&info.frames_per_second);
+        {
+            if args.bench_fn {
+                print_bench_results("--bench-fn", &info.timestamps_fn);
+            }
+            if args.bench_total {
+                print_bench_results("--bench-total", &info.timestamps_total);
+            }
         }
         let use_screen_format = match mode {
             SelectionDispatch::DimensionsOrOutput => {
@@ -52,17 +62,29 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[cfg(feature = "benchmark")]
-fn print_bench_results(fps: &[u32]) {
-    if fps.len() < 5 {
-        eprintln!("benchmark: not enough data (selection lasted less than 5 seconds)");
+fn print_bench_results(bench_type: &str, timestamps: &[u32]) {
+    if timestamps.len() < 2 {
+        eprintln!("{bench_type}: no data");
         return;
     }
-    let trimmed = &fps[1..fps.len() - 1];
-    let total: u64 = trimmed.iter().map(|&f| f as u64).sum();
-    let avg = total as f64 / trimmed.len() as f64;
-    let min = *trimmed.iter().min().unwrap();
-    eprintln!("benchmark results (first and last second excluded):");
-    eprintln!("  total frames : {total}");
-    eprintln!("  avg fps      : {avg:.1}");
-    eprintln!("  min fps      : {min}");
+    let frametimes: Vec<u32> = timestamps
+        .windows(2)
+        .map(|w| w[1].wrapping_sub(w[0]))
+        .collect();
+    let total = frametimes.len();
+    let sum: u64 = frametimes.iter().map(|&f| f as u64).sum();
+    let avg_ft = sum as f64 / total as f64;
+    let min_ft = *frametimes.iter().min().unwrap();
+    let max_ft = *frametimes.iter().max().unwrap();
+    let avg_fps = 1000.0 / avg_ft;
+    let min_fps = 1000.0 / max_ft as f64;
+    let max_fps = 1000.0 / min_ft.max(1) as f64;
+    eprintln!("{bench_type} results:");
+    eprintln!("  total frames  : {total}");
+    eprintln!("  avg fps       : {avg_fps:.1}");
+    eprintln!("  min fps       : {min_fps:.0}");
+    eprintln!("  max fps       : {max_fps:.0}");
+    eprintln!("  avg frametime : {avg_ft:.2}ms");
+    eprintln!("  min frametime : {min_ft}ms");
+    eprintln!("  max frametime : {max_ft}ms");
 }

--- a/waysip/src/main.rs
+++ b/waysip/src/main.rs
@@ -28,25 +28,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let boxes = read_boxes_from_stdin();
         let info = run_selection(&mut args, SelectionType::PredefinedBoxes, Some(boxes));
         #[cfg(feature = "benchmark")]
-        {
-            if args.bench_fn {
-                print_bench_results("--bench-fn", &info.timestamps_fn);
-            }
-            if args.bench_total {
-                print_bench_results("--bench-total", &info.timestamps_total);
-            }
+        if args.bench {
+            print_bench_results(SelectionType::PredefinedBoxes, &info.timestamps_total);
         }
         print!("{}", apply_format(&info, &fmt, false));
     } else if let Some(mode) = SelectionDispatch::from_cli(&args) {
-        let info = run_selection(&mut args, mode.selection_type(), None);
+        let selection_type = mode.selection_type();
+        let info = run_selection(&mut args, selection_type, None);
         #[cfg(feature = "benchmark")]
-        {
-            if args.bench_fn {
-                print_bench_results("--bench-fn", &info.timestamps_fn);
-            }
-            if args.bench_total {
-                print_bench_results("--bench-total", &info.timestamps_total);
-            }
+        if args.bench {
+            print_bench_results(selection_type, &info.timestamps_total);
         }
         let use_screen_format = match mode {
             SelectionDispatch::DimensionsOrOutput => {
@@ -62,29 +53,56 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[cfg(feature = "benchmark")]
-fn print_bench_results(bench_type: &str, timestamps: &[u32]) {
+fn print_bench_results(selection_type: SelectionType, timestamps: &[u32]) {
     if timestamps.len() < 2 {
-        eprintln!("{bench_type}: no data");
+        eprintln!("Bench err: no data");
         return;
     }
-    let frametimes: Vec<u32> = timestamps
-        .windows(2)
-        .map(|w| w[1].wrapping_sub(w[0]))
-        .collect();
-    let total = frametimes.len();
-    let sum: u64 = frametimes.iter().map(|&f| f as u64).sum();
-    let avg_ft = sum as f64 / total as f64;
+
+    let first = timestamps[0];
+    let mut rel: Vec<u32> = timestamps.iter().map(|&ts| ts - first).collect();
+    let raw_duration = *rel.last().unwrap();
+
+    let is_drag = matches!(
+        selection_type,
+        SelectionType::Area | SelectionType::DimensionsOrOutput
+    );
+    let trimmed_duration = if is_drag {
+        let to_cut = (raw_duration % 1000) / 2;
+        eprintln!("raw duration: {raw_duration}ms");
+        eprintln!("trimming {to_cut}ms from each end");
+        let cut_start = to_cut;
+        let cut_end_threshold = raw_duration.saturating_sub(to_cut);
+        rel.retain(|&ts| ts >= cut_start && ts <= cut_end_threshold);
+        if rel.len() < 2 {
+            eprintln!("bench err: not enough frames after trim");
+            return;
+        }
+        let new_first = rel[0];
+        for ts in rel.iter_mut() {
+            *ts -= new_first;
+        }
+        *rel.last().unwrap()
+    } else {
+        raw_duration
+    };
+
+    let frames = rel.len();
+    let frametimes: Vec<u32> = rel.windows(2).map(|w| w[1] - w[0]).collect();
+
+    let sum_ms: u64 = frametimes.iter().map(|&f| f as u64).sum();
+    let avg_ft = sum_ms as f64 / frametimes.len() as f64;
     let min_ft = *frametimes.iter().min().unwrap();
     let max_ft = *frametimes.iter().max().unwrap();
-    let avg_fps = 1000.0 / avg_ft;
-    let min_fps = 1000.0 / max_ft as f64;
-    let max_fps = 1000.0 / min_ft.max(1) as f64;
-    eprintln!("{bench_type} results:");
-    eprintln!("  total frames  : {total}");
+    let avg_fps = if trimmed_duration > 0 {
+        frames as f64 / (trimmed_duration as f64 / 1000.0)
+    } else {
+        0.0
+    };
+
     eprintln!("  avg fps       : {avg_fps:.1}");
-    eprintln!("  min fps       : {min_fps:.0}");
-    eprintln!("  max fps       : {max_fps:.0}");
     eprintln!("  avg frametime : {avg_ft:.2}ms");
     eprintln!("  min frametime : {min_ft}ms");
     eprintln!("  max frametime : {max_ft}ms");
+    eprintln!("  latencies     : {frametimes:?}");
 }

--- a/waysip/src/settings.rs
+++ b/waysip/src/settings.rs
@@ -110,6 +110,11 @@ pub(crate) fn run_selection(
         builder = builder.with_aspect_ratio(width, height);
     }
 
+    #[cfg(feature = "benchmark")]
+    if args.bench {
+        builder = builder.with_benchmark();
+    }
+
     match builder.get() {
         Ok(Some(info)) => info,
         Ok(None) => {

--- a/waysip/src/settings.rs
+++ b/waysip/src/settings.rs
@@ -111,8 +111,12 @@ pub(crate) fn run_selection(
     }
 
     #[cfg(feature = "benchmark")]
-    if args.bench {
-        builder = builder.with_benchmark();
+    if args.bench_fn {
+        builder = builder.with_bench_fn();
+    }
+    #[cfg(feature = "benchmark")]
+    if args.bench_total {
+        builder = builder.with_bench_total();
     }
 
     match builder.get() {

--- a/waysip/src/settings.rs
+++ b/waysip/src/settings.rs
@@ -111,12 +111,8 @@ pub(crate) fn run_selection(
     }
 
     #[cfg(feature = "benchmark")]
-    if args.bench_fn {
-        builder = builder.with_bench_fn();
-    }
-    #[cfg(feature = "benchmark")]
-    if args.bench_total {
-        builder = builder.with_bench_total();
+    if args.bench {
+        builder = builder.with_bench();
     }
 
     match builder.get() {


### PR DESCRIPTION
I'm still not happy about performance of waysip in compare with slurp.
To make development easier: optional feature `benchmark` was added, so user could call --bench alongside with desired feature to test during development.
I'm not sure whether it's correctly handled on lib side of project, so would appreciate all help.

Next target of performance optimisation already found with it:
```
user@l14g3Hyprland ~/m/waysip (pd)> ./target/debug/waysip -d --bench
benchmark results (first and last second excluded):
  total frames : 8431
  avg fps      : 526.9
  min fps      : 511
2914,606 1x1
user@l14g3Hyprland ~/m/waysip (pd)> ./target/debug/waysip -o --bench
benchmark results (first and last second excluded):
  total frames : 436
  avg fps      : 25.6
  min fps      : 24
1080,0 3440x1440
```
-o option unlike -d that I already worked on, still renders full instead of just damaged area, so would be useful to fix that.

Why commit feature instead of just use it as a patch:
rebasing it each time wouldn't be pleasant and it doesn't hurt release performance as it's optional.

Also frame-limit that I added in #63 was just a workaround to fix frame-time issues. Plan to continue working on this issue too. Testing with that workaround as feature would be much easier.
Doesn't affect release as it's a default feature.

ps. Benchmark testing done via external macros to have consistent mouse movement and click delays