### PR TITLE
feature: screen freeze

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          pacman -Syu --noconfirm base-devel wayland cairo pango
+          pacman -Syu --noconfirm base-devel wayland cairo pango libdrm mesa
 
       - name: Build (${{ matrix.name }})
         run: cargo build ${{ matrix.cargo_args }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install build dependencies
+        # TODO: rm `libdrm` and `mesa` post `libwayshot` 0.8.0 release
+        # see: https://github.com/waycrate/wayshot/pull/395
         run: |
           pacman -Syu --noconfirm base-devel wayland cairo pango libdrm mesa
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,8 @@ jobs:
           components: clippy rustfmt
 
       - name: Install build dependencies
+        # TODO: rm `libdrm` and `mesa` post `libwayshot` 0.8.0 release
+        # see: https://github.com/waycrate/wayshot/pull/395
         run: |
           pacman -Syu --noconfirm base-devel wayland cairo pango libdrm mesa
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          pacman -Syu --noconfirm base-devel wayland cairo pango
+          pacman -Syu --noconfirm base-devel wayland cairo pango libdrm mesa
 
       - name: Build
         run: cargo build --release
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          pacman -Syu --noconfirm base-devel wayland cairo pango
+          pacman -Syu --noconfirm base-devel wayland cairo pango libdrm mesa
 
       - name: Obtain crates.io token
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5

--- a/.github/workflows/fmt-clippy.yml
+++ b/.github/workflows/fmt-clippy.yml
@@ -47,6 +47,8 @@ jobs:
           key: ${{ matrix.features }}
 
       - name: Install build dependencies
+        # TODO: rm `libdrm` and `mesa` post `libwayshot` 0.8.0 release
+        # see: https://github.com/waycrate/wayshot/pull/395
         run: |
           pacman -Syu --noconfirm base-devel wayland cairo pango libdrm mesa
 

--- a/.github/workflows/fmt-clippy.yml
+++ b/.github/workflows/fmt-clippy.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          pacman -Syu --noconfirm base-devel wayland cairo pango
+          pacman -Syu --noconfirm base-devel wayland cairo pango libdrm mesa
 
       - name: Clippy (${{ matrix.features }})
         run: cargo clippy ${{ matrix.features }} -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Optional `freeze` feature and `--freeze` flag: freezes the screen while a selection is in progress.
+
 ## [0.6.1] - 2026-03-24
 
 ### Changed
+
 - Fixed panic on hyperland by @id3v1669
 - Set the namespace to osk
 - make dimension_or_output also show text

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -49,20 +49,46 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
+name = "autocfg"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "cairo-rs"
@@ -89,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -99,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6b04e07d8080154ed4ac03546d9a2b303cc2fe1901ba0b35b301516e289368"
+checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -115,9 +141,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -125,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -137,18 +163,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.0"
+version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_complete_nushell"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb9e9715d29a754b468591be588f6b926f5b0a1eb6a8b62acabeb66ff84d897"
+checksum = "933b05d5d83ff65fd7eaf5d106c792f2264908790a2642aca57429767b762ce2"
 dependencies = [
  "clap",
  "clap_complete",
@@ -156,14 +182,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -179,10 +205,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "drm"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80bc8c5c6c2941f70a55c15f8d9f00f9710ebda3ffda98075f996a0e6c92756f"
+dependencies = [
+ "bitflags",
+ "bytemuck",
+ "drm-ffi",
+ "drm-fourcc",
+ "libc",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "drm"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a41816e58f47f49acfd956651055ddcf137c4882c2098c30c448817af21183a"
+dependencies = [
+ "bitflags",
+ "bytemuck",
+ "bytemuck_derive",
+ "drm-ffi",
+ "drm-fourcc",
+ "libc",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "drm-ffi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51a91c9b32ac4e8105dec255e849e0d66e27d7c34d184364fb93e469db08f690"
+dependencies = [
+ "drm-sys",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "drm-fourcc"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aafbcdb8afc29c1a7ee5fbe53b5d62f4565b35a042a662ca9fecd0b54dae6f4"
+
+[[package]]
+name = "drm-sys"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8e1361066d91f5ffccff060a3c3be9c3ecde15be2959c1937595f7a82a9f8"
+dependencies = [
+ "libc",
+ "linux-raw-sys 0.9.4",
+]
 
 [[package]]
 name = "equivalent"
@@ -197,14 +287,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -213,31 +303,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -246,32 +330,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-macro",
@@ -281,23 +365,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.4.2"
+name = "gbm"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "ce852e998d3ca5e4a97014fb31c940dc5ef344ec7d364984525fd11e8a547e6a"
+dependencies = [
+ "bitflags",
+ "drm 0.14.1",
+ "drm-fourcc",
+ "gbm-sys",
+ "libc",
+ "wayland-backend",
+ "wayland-server",
+]
+
+[[package]]
+name = "gbm-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13a5f2acc785d8fb6bf6b7ab6bfb0ef5dad4f4d97e8e70bb8e470722312f76f"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
 name = "gio"
-version = "0.22.2"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816b6743c46b217aa8fba679095ac6f2162fd53259dc8f186fcdbff9c555db03"
+checksum = "8b3e1f669909c326b9413bde5a742097b8c90a7d78f45326db13668984769ded"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -312,22 +418,22 @@ dependencies = [
 
 [[package]]
 name = "gio-sys"
-version = "0.22.0"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64729ba2772c080448f9f966dba8f4456beeb100d8c28a865ef8a0f2ef4987e1"
+checksum = "353fdc7da7cd16da916104b1e0e4e7de380ec9c8aaa20d4d742d66310ab4b0d5"
 dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "glib"
-version = "0.22.3"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039f93465ac17e6cb02d16f16572cd3e43a77e736d5ecc461e71b9c9c5c0569c"
+checksum = "ddbcf514bd1881fc1b960e4e52b4e82873f4da3bceddbd58d42827b508888100"
 dependencies = [
  "bitflags",
  "futures-channel",
@@ -345,21 +451,21 @@ dependencies = [
 
 [[package]]
 name = "glib-macros"
-version = "0.22.2"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda575994e3689b1bc12f89c3df621ead46ff292623b76b4710a3a5b79be54bb"
+checksum = "506d23499707c7142898429757e8d9a3871d965239a2cb66dfa05052be6d6f19"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "glib-sys"
-version = "0.22.3"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eb23a616a3dbc7fc15bbd26f58756ff0b04c8a894df3f0680cd21011db6a642"
+checksum = "030967459f9f676851872c6304adea7825c6d462ec9b72554c733cf0c5952233"
 dependencies = [
  "libc",
  "system-deps",
@@ -367,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "gobject-sys"
-version = "0.22.0"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18eda93f09d3778f38255b231b17ef67195013a592c91624a4daf8bead875565"
+checksum = "22a861859b887a79cf461359c192c97a57d8fb0229dd291232e57aa11f6fa72c"
 dependencies = [
  "glib-sys",
  "libc",
@@ -378,18 +484,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -398,21 +495,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
+name = "image"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+]
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
- "serde",
- "serde_core",
+ "hashbrown",
 ]
 
 [[package]]
@@ -422,34 +523,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
-name = "itoa"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
+name = "libc"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libc"
-version = "0.2.183"
+name = "libloading"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libwayshot"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f3fdd0d3c6644b9682cdfbfdbe750af27f9e00ce92dfc7671e080d3cc894e1"
+dependencies = [
+ "drm 0.15.0",
+ "gbm",
+ "image",
+ "memmap2",
+ "rustix 1.1.4",
+ "thiserror",
+ "tracing",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
 
 [[package]]
 name = "libwaysip"
 version = "0.6.1"
 dependencies = [
  "cairo-rs",
+ "image",
+ "libwayshot",
  "memmap2",
  "pango",
  "pangocairo",
@@ -463,29 +583,60 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -494,7 +645,16 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -511,13 +671,12 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pango"
-version = "0.22.0"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d8f224eddef627b896d2f7b05725b3faedbd140e0e8343446f0d34f34238ee"
+checksum = "5d800d8d0de2ad5d0fb046f5344dbaba14a003cf3dd27cc21d85893d35ea316c"
 dependencies = [
  "gio",
  "glib",
- "libc",
  "pango-sys",
 ]
 
@@ -535,13 +694,12 @@ dependencies = [
 
 [[package]]
 name = "pangocairo"
-version = "0.22.0"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f15369c787b1cc59a5b86eff6afffd5a9716c5beb4969d20b307cebfe7e407"
+checksum = "738a2ef690f51487814ff7172e0417c8e4fa2d7567571e5eb299d38b47b543ab"
 dependencies = [
  "cairo-rs",
  "glib",
- "libc",
  "pango",
  "pangocairo-sys",
 ]
@@ -567,43 +725,39 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "quick-xml"
-version = "0.39.2"
+name = "pxfm"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -616,6 +770,19 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -623,63 +790,41 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.27"
+name = "scoped-tls"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
-
-[[package]]
-name = "serde"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
-dependencies = [
- "serde_core",
-]
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.149"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
-dependencies = [
- "itoa",
- "memchr",
- "serde",
- "serde_core",
- "zmij",
+ "syn 3.0.0",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -695,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "slab"
@@ -707,9 +852,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "strsim"
@@ -719,9 +864,20 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fac314a64dc9a36e61a9eb4261a5e9bbfbc922b27e518af97bc32b926cf967"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -730,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "system-deps"
-version = "7.0.7"
+version = "7.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c8f33736f986f16d69b6cb8b03f55ddcad5c41acc4ccc39dd88e84aa805e7f"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
 dependencies = [
  "cfg-expr",
  "heck",
@@ -743,9 +899,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -756,44 +912,44 @@ dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
- "rustix",
- "windows-sys",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.0",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -801,32 +957,32 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tracing"
@@ -847,7 +1003,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -892,12 +1048,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,58 +1066,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
-name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "wayland-backend"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,7 +1073,8 @@ checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix",
+ "rustix 1.1.4",
+ "scoped-tls",
  "smallvec",
  "wayland-sys",
 ]
@@ -987,7 +1086,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
  "bitflags",
- "rustix",
+ "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -998,16 +1097,16 @@ version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "wayland-client",
  "xcursor",
 ]
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.12"
+version = "0.32.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
 dependencies = [
  "bitflags",
  "wayland-backend",
@@ -1040,11 +1139,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-server"
+version = "0.31.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1846eb04c49182e04f4a099e2a830a2b745610bbc1d61246e206f29c7000a0"
+dependencies = [
+ "bitflags",
+ "downcast-rs",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
 name = "wayland-sys"
 version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
+ "dlib",
+ "libc",
+ "log",
+ "memoffset",
  "pkg-config",
 ]
 
@@ -1068,6 +1184,15 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -1076,113 +1201,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-
-[[package]]
-name = "winnow"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "xcursor"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
-
-[[package]]
-name = "zmij"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,9 +66,9 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.1"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -568,8 +568,6 @@ name = "libwaysip"
 version = "0.6.1"
 dependencies = [
  "cairo-rs",
- "image",
- "libwayshot",
  "memmap2",
  "pango",
  "pangocairo",
@@ -817,7 +815,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -875,9 +873,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fac314a64dc9a36e61a9eb4261a5e9bbfbc922b27e518af97bc32b926cf967"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -933,7 +931,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -1168,12 +1166,16 @@ dependencies = [
 name = "waysip"
 version = "0.6.1"
 dependencies = [
+ "cairo-rs",
  "clap",
  "clap_complete",
  "clap_complete_nushell",
+ "image",
+ "libwayshot",
  "libwaysip",
  "tracing",
  "tracing-subscriber",
+ "wayland-client",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,5 @@ readme = "README.md"
 [workspace.dependencies]
 libwaysip = { version = "0.6.1", path = "./libwaysip", default-features = false }
 tracing = "0.1"
+cairo-rs = "0.22"
+wayland-client = "0.31"

--- a/README.md
+++ b/README.md
@@ -69,23 +69,31 @@ waysip --completions pwsh >> $PROFILE
 waysip --completions nushell | save -f ~/.config/nushell/completions/waysip.nu
 ```
 
+Freeze the screen while selecting, so the visible desktop stays static instead of updating live (requires the optional `freeze` feature, see below):
+
+```bash
+waysip --freeze -d
+```
+
 # Optional features
 
-All features except `benchmark` are enabled in the default build. To reduce binary size or compile-time dependencies, features can be selectively disabled:
+All features except `benchmark` and `freeze` are enabled in the default build. To reduce binary size or compile-time dependencies, features can be selectively disabled, or `freeze` can be opted into:
 
 ```bash
 cargo build --no-default-features --features frame-limiter
 cargo build --no-default-features --features logger
 cargo build --no-default-features --features completions
 cargo build --no-default-features --features frame-limit,logger,completions
+cargo build --features freeze
 ```
 
-| Feature       | What it adds                                               | Extra dependency          |
-| ------------- | ---------------------------------------------------------- | ------------------------- |
-| `frame-limit` | Workaround to fix frametime issue on low frequency CPUs    | None                      |
-| `logger`      | `--log-level` flag, tracing output to stderr               | tracing-subscriber        |
-| `completions` | `--completions <SHELL>`, generate shell completion scripts | clap_complete (+ nushell) |
-| `benchmark`   | Benchmarking options for development described [here](#development-benchmarking)| None |
+| Feature       | What it adds                                                                     | Extra dependency          |
+| ------------- | -------------------------------------------------------------------------------- | ------------------------- |
+| `frame-limit` | Workaround to fix frametime issue on low frequency CPUs                          | None                      |
+| `logger`      | `--log-level` flag, tracing output to stderr                                     | tracing-subscriber        |
+| `completions` | `--completions <SHELL>`, generate shell completion scripts                       | clap_complete (+ nushell) |
+| `benchmark`   | Benchmarking options for development described [here](#development-benchmarking) | None                      |
+| `freeze`      | `--freeze`, freeze the screen while selecting                                    | libwayshot, image         |
 
 # Installation
 
@@ -122,6 +130,7 @@ nix run github:waycrate/waysip
 # Development benchmarking
 
 To enable benchmarking options use one of those options depending on usecase described later:
+
 ```bash
 cargo build --no-default-features --features "logger completions benchmark"
 cargo build --no-default-features --features "logger completions frame-limit benchmark"
@@ -136,6 +145,7 @@ Regarding `frame-limit` feature. It is a workaround enabled by default meant to 
 Records each `wl_callback.done` timestamp from the compositor for the focused screen (duplicate timestamps are dropped, so it's roughly one entry per frame) and prints frame stats on stderr when the selection ends.
 
 Reported metrics (written to stderr):
+
 - `fps avg`
 - `frametime: min / avg / max`
 - `latencies` - array of entries meant track where frametime issues happened
@@ -144,7 +154,6 @@ For drag modes the `raw duration` and the amount trimmed from each end are also 
 For non-drag options less frames-better.
 
 To test frametime stability try lowering your cpu freq to 0.8 GHz and build without frame-limit feature before testing.
-
 
 # Support:
 

--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,8 @@ allow = [
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
     "Unicode-3.0",
+    "ISC",
+    "BSD-2-Clause",
 ]
 confidence-threshold = 0.8
 private = { ignore = true }

--- a/libwaysip/Cargo.toml
+++ b/libwaysip/Cargo.toml
@@ -19,7 +19,7 @@ freeze = ["dep:libwayshot", "dep:image"]
 tempfile = "3.27"
 wayland-client = "0.31"
 wayland-cursor = "0.31"
-libwayshot = { version = "0.8", optional = true }
+libwayshot = { version = "0.8", optional = true, default-features = false }
 image = { version = "0.25", optional = true, default-features = false }
 
 wayland-protocols = { version = "0.32", default-features = false, features = [

--- a/libwaysip/Cargo.toml
+++ b/libwaysip/Cargo.toml
@@ -13,14 +13,11 @@ readme.workspace = true
 default = ["frame-limit"]
 frame-limit = []
 benchmark = []
-freeze = ["dep:libwayshot", "dep:image"]
 
 [dependencies]
 tempfile = "3.27"
-wayland-client = "0.31"
+wayland-client.workspace = true
 wayland-cursor = "0.31"
-libwayshot = { version = "0.8", optional = true, default-features = false }
-image = { version = "0.25", optional = true, default-features = false }
 
 wayland-protocols = { version = "0.32", default-features = false, features = [
 	"unstable",
@@ -32,7 +29,7 @@ wayland-protocols-wlr = { version = "0.3", default-features = false, features = 
 	"client",
 ] }
 
-cairo-rs = "0.22"
+cairo-rs.workspace = true
 pango = "0.22"
 pangocairo = "0.22"
 

--- a/libwaysip/Cargo.toml
+++ b/libwaysip/Cargo.toml
@@ -13,11 +13,14 @@ readme.workspace = true
 default = ["frame-limit"]
 frame-limit = []
 benchmark = []
+freeze = ["dep:libwayshot", "dep:image"]
 
 [dependencies]
 tempfile = "3.27"
 wayland-client = "0.31"
 wayland-cursor = "0.31"
+libwayshot = { version = "0.8", optional = true }
+image = { version = "0.25", optional = true, default-features = false }
 
 wayland-protocols = { version = "0.32", default-features = false, features = [
 	"unstable",

--- a/libwaysip/src/lib.rs
+++ b/libwaysip/src/lib.rs
@@ -47,6 +47,8 @@ pub struct WaySip {
     aspect_ratio: Option<(f64, f64)>,
     #[cfg(feature = "benchmark")]
     bench: bool,
+    #[cfg(feature = "freeze")]
+    freeze: bool,
 }
 
 impl WaySip {
@@ -111,10 +113,19 @@ impl WaySip {
         self
     }
 
+    /// Freeze the screen so the visible desktop stays static while selecting.
+    #[cfg(feature = "freeze")]
+    pub fn with_freeze(mut self) -> Self {
+        self.freeze = true;
+        self
+    }
+
     /// get the selected area
     pub fn get(self) -> Result<Option<state::AreaInfo>, WaySipError> {
         #[cfg(feature = "benchmark")]
         let bench = self.bench;
+        #[cfg(feature = "freeze")]
+        let freeze = self.freeze;
 
         match self.conn {
             Some(connection) => get_area_inner(
@@ -125,6 +136,8 @@ impl WaySip {
                 self.aspect_ratio,
                 #[cfg(feature = "benchmark")]
                 bench,
+                #[cfg(feature = "freeze")]
+                freeze,
             ),
             None => {
                 let connection = Connection::connect_to_env()
@@ -138,6 +151,8 @@ impl WaySip {
                     self.aspect_ratio,
                     #[cfg(feature = "benchmark")]
                     bench,
+                    #[cfg(feature = "freeze")]
+                    freeze,
                 )
             }
         }
@@ -151,6 +166,7 @@ fn get_area_inner(
     boxes: Option<Vec<state::BoxInfo>>,
     aspect_ratio: Option<(f64, f64)>,
     #[cfg(feature = "benchmark")] bench: bool,
+    #[cfg(feature = "freeze")] freeze: bool,
 ) -> Result<Option<state::AreaInfo>, WaySipError> {
     let (globals, _) = registry_queue_init::<state::WaysipState>(connection)
         .map_err(|e| WaySipError::InitFailed(e.to_string()))?;
@@ -214,6 +230,15 @@ fn get_area_inner(
     // you will find you get the outputs, but if you do not
     // do the step before, you get empty list
 
+    #[cfg(feature = "freeze")]
+    let frozen_backgrounds = if freeze {
+        capture_frozen_backgrounds(connection, &state.wloutput_infos)?
+    } else {
+        Vec::new()
+    };
+    #[cfg(feature = "freeze")]
+    let mut frozen_backgrounds = frozen_backgrounds.into_iter();
+
     let layer_shell = globals
         .bind::<ZwlrLayerShellV1, _, _>(&qh, 3..=4, ())
         .map_err(WaySipError::NotSupportedProtocol)?;
@@ -249,11 +274,21 @@ fn get_area_inner(
         // and if you need to reconfigure it, you need to commit the wl_surface again
         // so because this is just an example, so we just commit it once
         // like if you want to reset anchor or KeyboardInteractivity or resize, commit is needed
+        #[cfg(feature = "freeze")]
+        let frozen_bg = frozen_backgrounds.next().flatten();
+        #[cfg(not(feature = "freeze"))]
+        let frozen_bg: Option<cairo::ImageSurface> = None;
+
         let mut file = tempfile::tempfile().unwrap();
         let UiInit {
             context: cairo_t,
             stride,
-        } = render::draw_ui(&mut file, (init_w, init_h), style.background_color);
+        } = render::draw_ui(
+            &mut file,
+            (init_w, init_h),
+            style.background_color,
+            frozen_bg.as_ref(),
+        );
         let pool = shm.create_pool(file.as_fd(), init_w * init_h * 4, &qh, ());
 
         let buffer =
@@ -276,6 +311,7 @@ fn get_area_inner(
             font_desc_normal: std::cell::OnceCell::new(),
             prev_selection: None,
             margin: std::cell::OnceCell::new(),
+            frozen_bg,
         });
     }
     state.shm = Some(shm);
@@ -301,4 +337,68 @@ fn get_area_inner(
     }
     state.wl_surfaces.clear();
     Ok(state.area_info())
+}
+
+/// Takes a screenshot of every output before the selection UI is shown, so
+/// the visible desktop can be kept static ("frozen") while the user selects.
+#[cfg(feature = "freeze")]
+fn capture_frozen_backgrounds(
+    connection: &Connection,
+    outputs: &[state::WlOutputInfo],
+) -> Result<Vec<Option<cairo::ImageSurface>>, WaySipError> {
+    let wayshot_conn =
+        libwayshot::WayshotConnection::from_connection(connection.clone()).map_err(|e| {
+            WaySipError::InitFailed(format!("Failed to initialize screenshot backend: {e}"))
+        })?;
+    let available = wayshot_conn.get_all_outputs();
+
+    Ok(outputs
+        .iter()
+        .map(|wloutput| -> Option<cairo::ImageSurface> {
+            let output_info = available
+                .iter()
+                .find(|info| info.name == wloutput.get_name())?;
+            let image = wayshot_conn
+                .screenshot_single_output(output_info, false)
+                .ok()?;
+            image_to_argb_surface(image)
+        })
+        .collect())
+}
+
+/// Converts an [`image::DynamicImage`] into a premultiplied-alpha
+/// `cairo::ImageSurface` (`ARgb32`) suitable for use as a paint source.
+#[cfg(feature = "freeze")]
+fn image_to_argb_surface(image: image::DynamicImage) -> Option<cairo::ImageSurface> {
+    let rgba = image.to_rgba8();
+    let width = rgba.width() as i32;
+    let height = rgba.height() as i32;
+    if width == 0 || height == 0 {
+        return None;
+    }
+
+    let stride = cairo::Format::ARgb32.stride_for_width(width as u32).ok()?;
+    let src = rgba.as_raw();
+    let mut data = vec![0u8; stride as usize * height as usize];
+
+    for y in 0..height as usize {
+        let row = y * stride as usize;
+        for x in 0..width as usize {
+            let si = (y * width as usize + x) * 4;
+            let r = src[si] as u32;
+            let g = src[si + 1] as u32;
+            let b = src[si + 2] as u32;
+            let a = src[si + 3] as u32;
+            // cairo's ARgb32 stores premultiplied-alpha pixels.
+            let pr = r * a / 255;
+            let pg = g * a / 255;
+            let pb = b * a / 255;
+            let pixel = (a << 24) | (pr << 16) | (pg << 8) | pb;
+
+            let di = row + x * 4;
+            data[di..di + 4].copy_from_slice(&pixel.to_ne_bytes());
+        }
+    }
+
+    cairo::ImageSurface::create_for_data(data, cairo::Format::ARgb32, width, height, stride).ok()
 }

--- a/libwaysip/src/lib.rs
+++ b/libwaysip/src/lib.rs
@@ -9,12 +9,14 @@ pub use utils::*;
 use error::WaySipError;
 use render::UiInit;
 pub use state::{AreaInfo, BoxInfo, SelectionType};
+use std::fmt;
 use std::os::unix::prelude::AsFd;
 use wayland_client::{
     Connection,
     globals::registry_queue_init,
     protocol::{
         wl_compositor::WlCompositor,
+        wl_output::WlOutput,
         wl_seat::WlSeat,
         wl_shm::{self, WlShm},
     },
@@ -29,6 +31,13 @@ use wayland_protocols_wlr::layer_shell::v1::client::{
     zwlr_layer_surface_v1::{self, Anchor},
 };
 
+/// A callback invoked once per output right before its selection overlay is
+/// shown, letting the caller supply an image to use
+/// as that output's static backdrop, keeping the visible desktop "frozen"
+/// while selecting. Receives the output's `WlOutput` and its name (e.g.
+/// `"DP-1"`), and returns `None` to fall back to the normal live overlay.
+pub type BackgroundProvider = Box<dyn Fn(&WlOutput, &str) -> Option<cairo::ImageSurface>>;
+
 fn get_cursor_buffer(connection: &Connection, shm: &WlShm) -> Option<CursorImageBuffer> {
     let mut cursor_theme = CursorTheme::load(connection, shm.clone(), 23).ok()?;
     let mut cursor = cursor_theme.get_cursor("crosshair");
@@ -38,7 +47,7 @@ fn get_cursor_buffer(connection: &Connection, shm: &WlShm) -> Option<CursorImage
     Some(cursor?[0].clone())
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct WaySip {
     conn: Option<Connection>,
     selection_type: SelectionType,
@@ -47,8 +56,24 @@ pub struct WaySip {
     aspect_ratio: Option<(f64, f64)>,
     #[cfg(feature = "benchmark")]
     bench: bool,
-    #[cfg(feature = "freeze")]
-    freeze: bool,
+    background_provider: Option<BackgroundProvider>,
+}
+
+impl fmt::Debug for WaySip {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = f.debug_struct("WaySip");
+        debug
+            .field("conn", &self.conn)
+            .field("selection_type", &self.selection_type)
+            .field("style", &self.style)
+            .field("predefined_boxes", &self.predefined_boxes)
+            .field("aspect_ratio", &self.aspect_ratio);
+        #[cfg(feature = "benchmark")]
+        debug.field("bench", &self.bench);
+        debug
+            .field("background_provider", &self.background_provider.is_some())
+            .finish()
+    }
 }
 
 impl WaySip {
@@ -113,10 +138,17 @@ impl WaySip {
         self
     }
 
-    /// Freeze the screen so the visible desktop stays static while selecting.
-    #[cfg(feature = "freeze")]
-    pub fn with_freeze(mut self) -> Self {
-        self.freeze = true;
+    /// Supply a per-output background image to use as
+    /// the static backdrop for the selection overlay, instead of the normal
+    /// live desktop, keeping the screen "frozen" while selecting.
+    ///
+    /// The provider is called once per output; returning `None` for a given
+    /// output falls back to the regular (live) overlay for it.
+    pub fn with_background_provider<F>(mut self, provider: F) -> Self
+    where
+        F: Fn(&WlOutput, &str) -> Option<cairo::ImageSurface> + 'static,
+    {
+        self.background_provider = Some(Box::new(provider));
         self
     }
 
@@ -124,8 +156,6 @@ impl WaySip {
     pub fn get(self) -> Result<Option<state::AreaInfo>, WaySipError> {
         #[cfg(feature = "benchmark")]
         let bench = self.bench;
-        #[cfg(feature = "freeze")]
-        let freeze = self.freeze;
 
         match self.conn {
             Some(connection) => get_area_inner(
@@ -136,8 +166,7 @@ impl WaySip {
                 self.aspect_ratio,
                 #[cfg(feature = "benchmark")]
                 bench,
-                #[cfg(feature = "freeze")]
-                freeze,
+                self.background_provider,
             ),
             None => {
                 let connection = Connection::connect_to_env()
@@ -151,8 +180,7 @@ impl WaySip {
                     self.aspect_ratio,
                     #[cfg(feature = "benchmark")]
                     bench,
-                    #[cfg(feature = "freeze")]
-                    freeze,
+                    self.background_provider,
                 )
             }
         }
@@ -166,7 +194,7 @@ fn get_area_inner(
     boxes: Option<Vec<state::BoxInfo>>,
     aspect_ratio: Option<(f64, f64)>,
     #[cfg(feature = "benchmark")] bench: bool,
-    #[cfg(feature = "freeze")] freeze: bool,
+    background_provider: Option<BackgroundProvider>,
 ) -> Result<Option<state::AreaInfo>, WaySipError> {
     let (globals, _) = registry_queue_init::<state::WaysipState>(connection)
         .map_err(|e| WaySipError::InitFailed(e.to_string()))?;
@@ -230,15 +258,6 @@ fn get_area_inner(
     // you will find you get the outputs, but if you do not
     // do the step before, you get empty list
 
-    #[cfg(feature = "freeze")]
-    let frozen_backgrounds = if freeze {
-        capture_frozen_backgrounds(connection, &state.wloutput_infos)?
-    } else {
-        Vec::new()
-    };
-    #[cfg(feature = "freeze")]
-    let mut frozen_backgrounds = frozen_backgrounds.into_iter();
-
     let layer_shell = globals
         .bind::<ZwlrLayerShellV1, _, _>(&qh, 3..=4, ())
         .map_err(WaySipError::NotSupportedProtocol)?;
@@ -274,10 +293,9 @@ fn get_area_inner(
         // and if you need to reconfigure it, you need to commit the wl_surface again
         // so because this is just an example, so we just commit it once
         // like if you want to reset anchor or KeyboardInteractivity or resize, commit is needed
-        #[cfg(feature = "freeze")]
-        let frozen_bg = frozen_backgrounds.next().flatten();
-        #[cfg(not(feature = "freeze"))]
-        let frozen_bg: Option<cairo::ImageSurface> = None;
+        let frozen_bg = background_provider
+            .as_ref()
+            .and_then(|provider| provider(wloutput.get_output(), wloutput.get_name()));
 
         let mut file = tempfile::tempfile().unwrap();
         let UiInit {
@@ -337,68 +355,4 @@ fn get_area_inner(
     }
     state.wl_surfaces.clear();
     Ok(state.area_info())
-}
-
-/// Takes a screenshot of every output before the selection UI is shown, so
-/// the visible desktop can be kept static ("frozen") while the user selects.
-#[cfg(feature = "freeze")]
-fn capture_frozen_backgrounds(
-    connection: &Connection,
-    outputs: &[state::WlOutputInfo],
-) -> Result<Vec<Option<cairo::ImageSurface>>, WaySipError> {
-    let wayshot_conn =
-        libwayshot::WayshotConnection::from_connection(connection.clone()).map_err(|e| {
-            WaySipError::InitFailed(format!("Failed to initialize screenshot backend: {e}"))
-        })?;
-    let available = wayshot_conn.get_all_outputs();
-
-    Ok(outputs
-        .iter()
-        .map(|wloutput| -> Option<cairo::ImageSurface> {
-            let output_info = available
-                .iter()
-                .find(|info| info.name == wloutput.get_name())?;
-            let image = wayshot_conn
-                .screenshot_single_output(output_info, false)
-                .ok()?;
-            image_to_argb_surface(image)
-        })
-        .collect())
-}
-
-/// Converts an [`image::DynamicImage`] into a premultiplied-alpha
-/// `cairo::ImageSurface` (`ARgb32`) suitable for use as a paint source.
-#[cfg(feature = "freeze")]
-fn image_to_argb_surface(image: image::DynamicImage) -> Option<cairo::ImageSurface> {
-    let rgba = image.to_rgba8();
-    let width = rgba.width() as i32;
-    let height = rgba.height() as i32;
-    if width == 0 || height == 0 {
-        return None;
-    }
-
-    let stride = cairo::Format::ARgb32.stride_for_width(width as u32).ok()?;
-    let src = rgba.as_raw();
-    let mut data = vec![0u8; stride as usize * height as usize];
-
-    for y in 0..height as usize {
-        let row = y * stride as usize;
-        for x in 0..width as usize {
-            let si = (y * width as usize + x) * 4;
-            let r = src[si] as u32;
-            let g = src[si + 1] as u32;
-            let b = src[si + 2] as u32;
-            let a = src[si + 3] as u32;
-            // cairo's ARgb32 stores premultiplied-alpha pixels.
-            let pr = r * a / 255;
-            let pg = g * a / 255;
-            let pb = b * a / 255;
-            let pixel = (a << 24) | (pr << 16) | (pg << 8) | pb;
-
-            let di = row + x * 4;
-            data[di..di + 4].copy_from_slice(&pixel.to_ne_bytes());
-        }
-    }
-
-    cairo::ImageSurface::create_for_data(data, cairo::Format::ARgb32, width, height, stride).ok()
 }

--- a/libwaysip/src/render.rs
+++ b/libwaysip/src/render.rs
@@ -22,15 +22,15 @@ impl LayerSurfaceInfo {
         description: &str,
     ) {
         let cairoinfo = &self.cairo_t;
-        cairoinfo.set_operator(cairo::Operator::Source);
+        let frozen = self.frozen_bg.as_ref();
         if is_selected {
-            cairoinfo.set_source_rgba(
-                self.style.foreground_color.r,
-                self.style.foreground_color.g,
-                self.style.foreground_color.b,
-                self.style.foreground_color.a,
+            paint_background(
+                cairoinfo,
+                frozen,
+                self.style.foreground_color,
+                width,
+                height,
             );
-            cairoinfo.paint().unwrap();
 
             cairoinfo.set_source_rgba(
                 self.style.border_text_color.r,
@@ -87,13 +87,13 @@ impl LayerSurfaceInfo {
             cairoinfo.restore().unwrap();
             cairoinfo.set_operator(cairo::Operator::Over);
         } else {
-            cairoinfo.set_source_rgba(
-                self.style.background_color.r,
-                self.style.background_color.g,
-                self.style.background_color.b,
-                self.style.background_color.a,
+            paint_background(
+                cairoinfo,
+                frozen,
+                self.style.background_color,
+                width,
+                height,
             );
-            cairoinfo.paint().unwrap();
         }
 
         self.wl_surface.attach(Some(&self.buffer), 0, 0);
@@ -119,6 +119,7 @@ impl LayerSurfaceInfo {
         redraw_all: bool,
     ) {
         let cairoinfo = &self.cairo_t;
+        let frozen = self.frozen_bg.as_ref();
 
         let current_sel = {
             let rx1 = (start_pos_x - start_x as f64).min(end_pos.x - start_x as f64);
@@ -186,21 +187,20 @@ impl LayerSurfaceInfo {
             cairoinfo.rectangle(dx as f64, dy as f64, dw as f64, dh as f64);
             cairoinfo.clip();
         }
-        cairoinfo.set_operator(cairo::Operator::Source);
-        cairoinfo.set_source_rgba(
-            self.style.background_color.r,
-            self.style.background_color.g,
-            self.style.background_color.b,
-            self.style.background_color.a,
+        paint_background(
+            cairoinfo,
+            frozen,
+            self.style.background_color,
+            width,
+            height,
         );
-        cairoinfo.paint().unwrap();
-
         if !redraw_all {
             cairoinfo.restore().unwrap();
-
-            cairoinfo.set_operator(cairo::Operator::Source);
         }
-
+        cairoinfo.set_operator(match frozen {
+            Some(_) => cairo::Operator::Over,
+            None => cairo::Operator::Source,
+        });
         if let Some(boxes) = opt_boxes {
             for box_info in boxes {
                 let bstart_x = box_info.start_x - start_x as f64;
@@ -227,6 +227,15 @@ impl LayerSurfaceInfo {
         let relate_end_y = end_pos.y - start_y as f64;
         let rlwidth = relate_end_x - relate_start_x;
         let rlheight = relate_end_y - relate_start_y;
+
+        if let Some(frozen) = frozen {
+            cairoinfo.save().unwrap();
+            cairoinfo.rectangle(relate_start_x, relate_start_y, rlwidth, rlheight);
+            cairoinfo.clip();
+            paint_frozen_image(cairoinfo, frozen, width, height);
+            cairoinfo.restore().unwrap();
+            cairoinfo.set_operator(cairo::Operator::Over);
+        }
 
         cairoinfo.rectangle(relate_start_x, relate_start_y, rlwidth, rlheight);
         cairoinfo.set_source_rgba(
@@ -298,6 +307,7 @@ pub fn draw_ui(
     tmp: &mut File,
     (width, height): (i32, i32),
     background_color: crate::Color,
+    frozen_bg: Option<&cairo::ImageSurface>,
 ) -> UiInit {
     let cairo_fmt = Format::ARgb32;
     let stride = cairo_fmt.stride_for_width(width as u32).unwrap();
@@ -307,6 +317,30 @@ pub fn draw_ui(
     let surface =
         cairo::ImageSurface::create_for_data(mmmap, cairo_fmt, width, height, stride).unwrap();
     let cairoinfo = cairo::Context::new(&surface).unwrap();
+    paint_background(&cairoinfo, frozen_bg, background_color, width, height);
+    UiInit {
+        context: cairoinfo,
+        stride,
+    }
+}
+
+/// Paints the "resting" backdrop of a surface: either the plain
+/// `background_color`, or a screenshot taken before the
+/// selection UI was shown, dimmed by `background_color` on top of it.
+fn paint_background(
+    cairoinfo: &Context,
+    frozen_bg: Option<&cairo::ImageSurface>,
+    background_color: crate::Color,
+    width: i32,
+    height: i32,
+) {
+    match frozen_bg {
+        Some(frozen) => {
+            paint_frozen_image(cairoinfo, frozen, width, height);
+            cairoinfo.set_operator(cairo::Operator::Over);
+        }
+        None => cairoinfo.set_operator(cairo::Operator::Source),
+    }
     cairoinfo.set_source_rgba(
         background_color.r,
         background_color.g,
@@ -314,8 +348,19 @@ pub fn draw_ui(
         background_color.a,
     );
     cairoinfo.paint().unwrap();
-    UiInit {
-        context: cairoinfo,
-        stride,
+}
+
+/// Paints a frozen screenshot as an opaque backdrop, scaling it to fit
+/// `(width, height)` if its own dimensions don't match.
+fn paint_frozen_image(cairoinfo: &Context, frozen: &cairo::ImageSurface, width: i32, height: i32) {
+    let shot_w = frozen.width();
+    let shot_h = frozen.height();
+    cairoinfo.save().unwrap();
+    if shot_w != width || shot_h != height {
+        cairoinfo.scale(width as f64 / shot_w as f64, height as f64 / shot_h as f64);
     }
+    cairoinfo.set_operator(cairo::Operator::Source);
+    cairoinfo.set_source_surface(frozen, 0.0, 0.0).unwrap();
+    cairoinfo.paint().unwrap();
+    cairoinfo.restore().unwrap();
 }

--- a/libwaysip/src/state.rs
+++ b/libwaysip/src/state.rs
@@ -283,6 +283,7 @@ impl WaysipState {
             &mut file,
             (width, height),
             surface_info.style.background_color,
+            surface_info.frozen_bg.as_ref(),
         );
         let pool = self
             .shm
@@ -461,6 +462,7 @@ pub(crate) struct LayerSurfaceInfo {
     pub font_desc_normal: std::cell::OnceCell<pango::FontDescription>,
     pub prev_selection: Option<[f64; 4]>,
     pub margin: std::cell::OnceCell<(f64, f64)>,
+    pub frozen_bg: Option<cairo::ImageSurface>,
 }
 
 /// coordinates of box

--- a/waysip/Cargo.toml
+++ b/waysip/Cargo.toml
@@ -20,6 +20,7 @@ logger = ["dep:tracing-subscriber"]
 completions = ["dep:clap_complete", "dep:clap_complete_nushell"]
 frame-limit = ["libwaysip/frame-limit"]
 benchmark = ["libwaysip/benchmark"]
+freeze = ["libwaysip/freeze"]
 
 [dependencies]
 clap = { version = "4.6", features = ["derive"] }

--- a/waysip/Cargo.toml
+++ b/waysip/Cargo.toml
@@ -20,12 +20,18 @@ logger = ["dep:tracing-subscriber"]
 completions = ["dep:clap_complete", "dep:clap_complete_nushell"]
 frame-limit = ["libwaysip/frame-limit"]
 benchmark = ["libwaysip/benchmark"]
-freeze = ["libwaysip/freeze"]
+# Captures a screenshot of each output (via `libwayshot`) and uses it as a
+# static backdrop while selecting, giving the effect of a frozen screen.
+freeze = ["dep:libwayshot", "dep:image", "dep:cairo-rs", "dep:wayland-client"]
 
 [dependencies]
+cairo-rs = { workspace = true, optional = true }
 clap = { version = "4.6", features = ["derive"] }
 clap_complete = { version = "4.6", optional = true }
 clap_complete_nushell = { version = "4.6", optional = true }
+image = { version = "0.25", optional = true, default-features = false }
 libwaysip.workspace = true
+libwayshot = { version = "0.8", optional = true, default-features = false }
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", optional = true }
+wayland-client = { workspace = true, optional = true }

--- a/waysip/src/cli.rs
+++ b/waysip/src/cli.rs
@@ -115,4 +115,9 @@ pub struct Cli {
     #[cfg(feature = "benchmark")]
     #[arg(long)]
     pub bench: bool,
+
+    /// Freeze the screen (via a screenshot) while selecting.
+    #[cfg(feature = "freeze")]
+    #[arg(long)]
+    pub freeze: bool,
 }

--- a/waysip/src/freeze.rs
+++ b/waysip/src/freeze.rs
@@ -1,0 +1,87 @@
+//! Captures a screenshot of every output (via `libwayshot`) so it can be
+//! used as the static backdrop for the selection overlay, giving the effect
+//! of a frozen screen while selecting.
+
+use std::collections::HashMap;
+
+use wayland_client::protocol::wl_output::WlOutput;
+
+/// Takes a screenshot of every output up front and returns a
+/// [`libwaysip::BackgroundProvider`]-compatible closure that looks up the
+/// pre-captured image for a given output by name.
+///
+/// Returns `None` (falling back to the normal, non-frozen overlay) if the
+/// screenshot backend itself couldn't be initialised.
+pub fn capture_backgrounds()
+-> Option<impl Fn(&WlOutput, &str) -> Option<cairo::ImageSurface> + 'static> {
+    let wayshot_conn = match libwayshot::WayshotConnection::new() {
+        Ok(conn) => conn,
+        Err(e) => {
+            eprintln!("Warning: freeze: failed to initialize screenshot backend: {e}");
+            return None;
+        }
+    };
+
+    let mut backgrounds: HashMap<String, cairo::ImageSurface> = HashMap::new();
+    for output_info in wayshot_conn.get_all_outputs() {
+        let image = match wayshot_conn.screenshot_single_output(output_info, false) {
+            Ok(image) => image,
+            Err(e) => {
+                eprintln!(
+                    "Warning: freeze: failed to capture output {}: {e}",
+                    output_info.name
+                );
+                continue;
+            }
+        };
+        match image_to_argb_surface(image) {
+            Some(surface) => {
+                backgrounds.insert(output_info.name.clone(), surface);
+            }
+            None => {
+                eprintln!(
+                    "Warning: freeze: failed to convert screenshot for output {}",
+                    output_info.name
+                );
+            }
+        }
+    }
+
+    Some(move |_wl_output: &WlOutput, name: &str| backgrounds.get(name).cloned())
+}
+
+/// Converts an [`image::DynamicImage`] into a premultiplied-alpha
+/// `cairo::ImageSurface` (`ARgb32`) suitable for use as a paint source.
+fn image_to_argb_surface(image: image::DynamicImage) -> Option<cairo::ImageSurface> {
+    let rgba = image.to_rgba8();
+    let width = rgba.width() as i32;
+    let height = rgba.height() as i32;
+    if width == 0 || height == 0 {
+        return None;
+    }
+
+    let stride = cairo::Format::ARgb32.stride_for_width(width as u32).ok()?;
+    let src = rgba.as_raw();
+    let mut data = vec![0u8; stride as usize * height as usize];
+
+    for y in 0..height as usize {
+        let row = y * stride as usize;
+        for x in 0..width as usize {
+            let si = (y * width as usize + x) * 4;
+            let r = src[si] as u32;
+            let g = src[si + 1] as u32;
+            let b = src[si + 2] as u32;
+            let a = src[si + 3] as u32;
+            // cairo's ARgb32 stores premultiplied-alpha pixels.
+            let pr = r * a / 255;
+            let pg = g * a / 255;
+            let pb = b * a / 255;
+            let pixel = (a << 24) | (pr << 16) | (pg << 8) | pb;
+
+            let di = row + x * 4;
+            data[di..di + 4].copy_from_slice(&pixel.to_ne_bytes());
+        }
+    }
+
+    cairo::ImageSurface::create_for_data(data, cairo::Format::ARgb32, width, height, stride).ok()
+}

--- a/waysip/src/main.rs
+++ b/waysip/src/main.rs
@@ -1,4 +1,6 @@
 mod cli;
+#[cfg(feature = "freeze")]
+mod freeze;
 #[cfg(feature = "logger")]
 mod logger;
 mod settings;

--- a/waysip/src/settings.rs
+++ b/waysip/src/settings.rs
@@ -116,8 +116,10 @@ pub(crate) fn run_selection(
     }
 
     #[cfg(feature = "freeze")]
-    if args.freeze {
-        builder = builder.with_freeze();
+    if args.freeze
+        && let Some(provider) = crate::freeze::capture_backgrounds()
+    {
+        builder = builder.with_background_provider(provider);
     }
 
     match builder.get() {

--- a/waysip/src/settings.rs
+++ b/waysip/src/settings.rs
@@ -115,6 +115,11 @@ pub(crate) fn run_selection(
         builder = builder.with_bench();
     }
 
+    #[cfg(feature = "freeze")]
+    if args.freeze {
+        builder = builder.with_freeze();
+    }
+
     match builder.get() {
         Ok(Some(info)) => info,
         Ok(None) => {


### PR DESCRIPTION
This PR addes screen freeze feature via `libwayshot`'s capabilities. The usecase for this is running `wayshot -g $"(waysip -d --freeze)"` -- since calling a binary on `wayshot -g $"(waysip -d)"` is impossible to make freezable without dirty hacks (e.g. adding `waysip`/`slurp`/etc cmd tracking on `wayshot` side).
I only added a minimal subset of `libwayshot`/`image` crate's features, so it does not pull lots of new deps, plus I made it completely optional.