### PR TITLE
feature: allow edit selection area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Optional `freeze` feature and `--freeze` flag: freezes the screen while a selection is in progress.
+- `--tweak` flag: after making an area/dimensions selection, shows draggable handles on
+  the 4 corners so the rectangle can be adjusted before confirming with a hotkey
+  (Enter by default, configurable with `--tweak-key <keycode>`).
 
 ## [0.6.1] - 2026-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Optional `freeze` feature and `--freeze` flag: freezes the screen while a selection is in progress.
-- `--tweak` flag: after making an area/dimensions selection, shows draggable handles on
-  the 4 corners so the rectangle can be adjusted before confirming with a hotkey
-  (Enter by default, configurable with `--tweak-key <keycode>`).
+- `--edit-selection` / `-e` flag: after making an area/dimensions selection, shows draggable
+  handles on the 4 corners so the rectangle can be adjusted before confirming with a hotkey
+  (Enter by default, configurable with `--edit-selection-key <keycode>`).
 
 ## [0.6.1] - 2026-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional `freeze` feature and `--freeze` flag: freezes the screen while a selection is in progress.
 - `--edit-selection` / `-e` flag: after making an area/dimensions selection, shows draggable
   handles on the 4 corners so the rectangle can be adjusted before confirming with a hotkey
-  (Enter by default, configurable with `--edit-selection-key <keycode>`).
+  (Enter by default, configurable with `--edit-selection-key <keycode>`). The whole rectangle
+  can also be dragged from its interior to move it.
 
 ## [0.6.1] - 2026-03-24
 

--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ Freeze the screen while selecting, so the visible desktop stays static instead o
 waysip --freeze -d
 ```
 
-Tweak the selection before confirming it, like flameshot: drag out a rectangle, then adjust
-its 4 corner handles as needed, then press Enter (or the key set with `--tweak-key <keycode>`)
+Edit the selection before confirming it, like flameshot: drag out a rectangle, then adjust
+its 4 corner handles as needed, then press Enter (or the key set with `--edit-selection-key <keycode>`)
 to confirm:
 
 ```bash
-waysip -d --tweak
+waysip -d -e
 ```
 
 # Optional features

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ Freeze the screen while selecting, so the visible desktop stays static instead o
 waysip --freeze -d
 ```
 
+Tweak the selection before confirming it, like flameshot: drag out a rectangle, then adjust
+its 4 corner handles as needed, then press Enter (or the key set with `--tweak-key <keycode>`)
+to confirm:
+
+```bash
+waysip -d --tweak
+```
+
 # Optional features
 
 All features except `benchmark` and `freeze` are enabled in the default build. To reduce binary size or compile-time dependencies, features can be selectively disabled, or `freeze` can be opted into:

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ waysip --freeze -d
 ```
 
 Edit the selection before confirming it, like flameshot: drag out a rectangle, then adjust
-its 4 corner handles as needed, then press Enter (or the key set with `--edit-selection-key <keycode>`)
-to confirm:
+its 4 corner handles as needed (or drag anywhere inside it to move the whole rectangle),
+then press Enter (or the key set with `--edit-selection-key <keycode>`) to confirm:
 
 ```bash
 waysip -d -e

--- a/libwaysip/src/dispatch.rs
+++ b/libwaysip/src/dispatch.rs
@@ -231,7 +231,11 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                     WEnum::Value(wl_pointer::ButtonState::Pressed) => {
                         if dispatch_state.editing {
                             dispatch_state.active_handle =
-                                dispatch_state.hit_test_handle(dispatch_state.current_pos);
+                                dispatch_state.hit_test(dispatch_state.current_pos);
+                            if dispatch_state.active_handle == Some(crate::state::DragTarget::Body)
+                            {
+                                dispatch_state.begin_move_drag();
+                            }
                         } else {
                             if dispatch_state.is_dimensions_or_output() {
                                 // Record the press time for detecting single click vs drag
@@ -261,6 +265,7 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                     WEnum::Value(wl_pointer::ButtonState::Released) => {
                         if dispatch_state.editing {
                             dispatch_state.active_handle = None;
+                            dispatch_state.move_anchor = None;
                         } else if dispatch_state.is_dimensions_or_output() {
                             // Determine if this was a single click or drag
                             let is_single_click =

--- a/libwaysip/src/dispatch.rs
+++ b/libwaysip/src/dispatch.rs
@@ -226,7 +226,8 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
         qh: &wayland_client::QueueHandle<Self>,
     ) {
         match event {
-            wl_pointer::Event::Button { state, .. } => {
+            wl_pointer::Event::Button { serial, state, .. } => {
+                dispatch_state.last_pointer_serial = Some(serial);
                 match state {
                     WEnum::Value(wl_pointer::ButtonState::Pressed) => {
                         if dispatch_state.editing {
@@ -329,22 +330,13 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                 surface_x,
                 surface_y,
             } => {
-                let Some(LayerSurfaceInfo {
-                    cursor_surface,
-                    cursor_buffer,
-                    ..
-                }) = dispatch_state
-                    .wl_surfaces
-                    .iter()
-                    .find(|info| info.wl_surface == surface)
-                else {
-                    return;
-                };
-                let current_screen = dispatch_state
+                let Some(current_screen) = dispatch_state
                     .wl_surfaces
                     .iter()
                     .position(|info| info.wl_surface == surface)
-                    .unwrap();
+                else {
+                    return;
+                };
                 dispatch_state.current_screen = current_screen;
                 let info =
                     dispatch_state.wloutput_infos[dispatch_state.current_screen].xdg_output_info();
@@ -355,22 +347,10 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                     y: surface_y + start_y as f64,
                 };
 
-                if let Some(ref cursor_manager) = dispatch_state.cursor_manager {
-                    let device = cursor_manager.get_pointer(pointer, qh, ());
-                    device.set_shape(serial, wp_cursor_shape_device_v1::Shape::Crosshair);
-                    device.destroy();
-                } else {
-                    let cursor_buffer = cursor_buffer.as_ref().unwrap();
-                    cursor_surface.attach(Some(cursor_buffer), 0, 0);
-                    let (hotspot_x, hotspot_y) = cursor_buffer.hotspot();
-                    pointer.set_cursor(
-                        serial,
-                        Some(cursor_surface),
-                        hotspot_x as i32,
-                        hotspot_y as i32,
-                    );
-                    cursor_surface.commit();
-                }
+                dispatch_state.last_pointer_serial = Some(serial);
+                // Force a fresh cursor-shape request since we just entered the surface.
+                dispatch_state.cursor_is_crosshair = None;
+                apply_cursor_shape(dispatch_state, pointer, qh, serial);
 
                 dispatch_state.try_commit();
             }
@@ -387,6 +367,10 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                     x: surface_x + start_x as f64,
                     y: surface_y + start_y as f64,
                 };
+
+                if let Some(serial) = dispatch_state.last_pointer_serial {
+                    apply_cursor_shape(dispatch_state, pointer, qh, serial);
+                }
 
                 if dispatch_state.editing {
                     if dispatch_state.active_handle.is_some() {
@@ -453,6 +437,70 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
             }
             _ => {}
         }
+    }
+}
+
+/// Sets the pointer's cursor shape: a crosshair while making the initial
+/// selection, over a corner handle, or while dragging the rectangle body;
+/// the regular system cursor otherwise (e.g. hovering elsewhere over the
+/// screen while editing a selection).
+fn apply_cursor_shape(
+    dispatch_state: &mut WaysipState,
+    pointer: &wl_pointer::WlPointer,
+    qh: &wayland_client::QueueHandle<WaysipState>,
+    serial: u32,
+) {
+    let crosshair = !dispatch_state.editing
+        || dispatch_state.active_handle.is_some()
+        || dispatch_state
+            .hit_test(dispatch_state.current_pos)
+            .is_some();
+
+    if dispatch_state.cursor_is_crosshair == Some(crosshair) {
+        return;
+    }
+    dispatch_state.cursor_is_crosshair = Some(crosshair);
+
+    if let Some(ref cursor_manager) = dispatch_state.cursor_manager {
+        let device = cursor_manager.get_pointer(pointer, qh, ());
+        let shape = if crosshair {
+            wp_cursor_shape_device_v1::Shape::Crosshair
+        } else {
+            wp_cursor_shape_device_v1::Shape::Default
+        };
+        device.set_shape(serial, shape);
+        device.destroy();
+        return;
+    }
+
+    // Fallback path for compositors without the cursor-shape protocol: attach
+    // a themed crosshair cursor image, or clear the cursor entirely (which
+    // makes the compositor show its own default cursor) otherwise.
+    if crosshair {
+        let Some(LayerSurfaceInfo {
+            cursor_surface,
+            cursor_buffer,
+            ..
+        }) = dispatch_state
+            .wl_surfaces
+            .get(dispatch_state.current_screen)
+        else {
+            return;
+        };
+        let Some(cursor_buffer) = cursor_buffer.as_ref() else {
+            return;
+        };
+        cursor_surface.attach(Some(cursor_buffer), 0, 0);
+        let (hotspot_x, hotspot_y) = cursor_buffer.hotspot();
+        pointer.set_cursor(
+            serial,
+            Some(cursor_surface),
+            hotspot_x as i32,
+            hotspot_y as i32,
+        );
+        cursor_surface.commit();
+    } else {
+        pointer.set_cursor(serial, None, 0, 0);
     }
 }
 

--- a/libwaysip/src/dispatch.rs
+++ b/libwaysip/src/dispatch.rs
@@ -206,7 +206,7 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for state::WaysipState {
             ..
         } = event
         {
-            let confirm_pressed = state.tweak_mode
+            let confirm_pressed = state.editing
                 && key == state.confirm_key
                 && matches!(key_state, WEnum::Value(wl_keyboard::KeyState::Pressed));
             if key == 1 || confirm_pressed {
@@ -229,7 +229,7 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
             wl_pointer::Event::Button { state, .. } => {
                 match state {
                     WEnum::Value(wl_pointer::ButtonState::Pressed) => {
-                        if dispatch_state.tweak_mode {
+                        if dispatch_state.editing {
                             dispatch_state.active_handle =
                                 dispatch_state.hit_test_handle(dispatch_state.current_pos);
                         } else {
@@ -259,7 +259,7 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                         }
                     }
                     WEnum::Value(wl_pointer::ButtonState::Released) => {
-                        if dispatch_state.tweak_mode {
+                        if dispatch_state.editing {
                             dispatch_state.active_handle = None;
                         } else if dispatch_state.is_dimensions_or_output() {
                             // Determine if this was a single click or drag
@@ -306,10 +306,10 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                                     Some(crate::state::SelectionType::Area);
                                 dispatch_state.end_pos = Some(dispatch_state.current_pos);
                             }
-                            dispatch_state.finish_or_enter_tweak();
+                            dispatch_state.finish_or_start_editing();
                         } else if !dispatch_state.is_predefined_boxes() {
                             dispatch_state.end_pos = Some(dispatch_state.current_pos);
-                            dispatch_state.finish_or_enter_tweak();
+                            dispatch_state.finish_or_start_editing();
                         } else {
                             dispatch_state.running = false;
                         }
@@ -383,7 +383,7 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                     y: surface_y + start_y as f64,
                 };
 
-                if dispatch_state.tweak_mode {
+                if dispatch_state.editing {
                     if dispatch_state.active_handle.is_some() {
                         dispatch_state.apply_handle_drag();
                         dispatch_state.try_commit();

--- a/libwaysip/src/dispatch.rs
+++ b/libwaysip/src/dispatch.rs
@@ -200,8 +200,18 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for state::WaysipState {
         _conn: &Connection,
         _qhandle: &wayland_client::QueueHandle<Self>,
     ) {
-        if let wl_keyboard::Event::Key { key: 1, .. } = event {
-            state.running = false;
+        if let wl_keyboard::Event::Key {
+            key,
+            state: key_state,
+            ..
+        } = event
+        {
+            let confirm_pressed = state.tweak_mode
+                && key == state.confirm_key
+                && matches!(key_state, WEnum::Value(wl_keyboard::KeyState::Pressed));
+            if key == 1 || confirm_pressed {
+                state.running = false;
+            }
         }
     }
 }
@@ -219,32 +229,39 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
             wl_pointer::Event::Button { state, .. } => {
                 match state {
                     WEnum::Value(wl_pointer::ButtonState::Pressed) => {
-                        if dispatch_state.is_dimensions_or_output() {
-                            // Record the press time for detecting single click vs drag
-                            dispatch_state.mouse_press_time = Some(std::time::Instant::now());
-                        }
+                        if dispatch_state.tweak_mode {
+                            dispatch_state.active_handle =
+                                dispatch_state.hit_test_handle(dispatch_state.current_pos);
+                        } else {
+                            if dispatch_state.is_dimensions_or_output() {
+                                // Record the press time for detecting single click vs drag
+                                dispatch_state.mouse_press_time = Some(std::time::Instant::now());
+                            }
 
-                        #[cfg(feature = "benchmark")]
-                        if dispatch_state.bench
-                            && (dispatch_state.is_area()
-                                || dispatch_state.is_dimensions_or_output())
-                        {
-                            dispatch_state.timestamps_total.clear();
-                        }
+                            #[cfg(feature = "benchmark")]
+                            if dispatch_state.bench
+                                && (dispatch_state.is_area()
+                                    || dispatch_state.is_dimensions_or_output())
+                            {
+                                dispatch_state.timestamps_total.clear();
+                            }
 
-                        if !dispatch_state.is_predefined_boxes() {
-                            dispatch_state.set_start_pos(dispatch_state.current_pos);
-                        }
-                        if !dispatch_state.is_area()
-                            && !dispatch_state.is_predefined_boxes()
-                            && !dispatch_state.is_dimensions_or_output()
-                        {
-                            dispatch_state.end_pos = Some(dispatch_state.current_pos);
-                            dispatch_state.running = false;
+                            if !dispatch_state.is_predefined_boxes() {
+                                dispatch_state.set_start_pos(dispatch_state.current_pos);
+                            }
+                            if !dispatch_state.is_area()
+                                && !dispatch_state.is_predefined_boxes()
+                                && !dispatch_state.is_dimensions_or_output()
+                            {
+                                dispatch_state.end_pos = Some(dispatch_state.current_pos);
+                                dispatch_state.running = false;
+                            }
                         }
                     }
                     WEnum::Value(wl_pointer::ButtonState::Released) => {
-                        if dispatch_state.is_dimensions_or_output() {
+                        if dispatch_state.tweak_mode {
+                            dispatch_state.active_handle = None;
+                        } else if dispatch_state.is_dimensions_or_output() {
                             // Determine if this was a single click or drag
                             let is_single_click =
                                 if let Some(press_time) = dispatch_state.mouse_press_time {
@@ -289,10 +306,13 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                                     Some(crate::state::SelectionType::Area);
                                 dispatch_state.end_pos = Some(dispatch_state.current_pos);
                             }
+                            dispatch_state.finish_or_enter_tweak();
                         } else if !dispatch_state.is_predefined_boxes() {
                             dispatch_state.end_pos = Some(dispatch_state.current_pos);
+                            dispatch_state.finish_or_enter_tweak();
+                        } else {
+                            dispatch_state.running = false;
                         }
-                        dispatch_state.running = false;
                     }
                     _ => {}
                 }
@@ -362,60 +382,68 @@ impl Dispatch<wl_pointer::WlPointer, ()> for state::WaysipState {
                     x: surface_x + start_x as f64,
                     y: surface_y + start_y as f64,
                 };
-                dispatch_state.end_pos = None;
 
-                // NOTE:  when it is area, we just use one click to get the position, so we
-                // need to know the end_pos immediately. so even the start_pos is not decided, we
-                // still need an end_pos
-                if dispatch_state.is_area() || dispatch_state.is_dimensions_or_output() {
-                    if let Some(ratio) = dispatch_state.aspect_ratio {
-                        let width_rel = ratio.0;
-                        let height_rel = ratio.1;
-                        let start_pos = dispatch_state
-                            .start_pos
-                            .unwrap_or(dispatch_state.current_pos);
-                        let width = dispatch_state.current_pos.x - start_pos.x;
-                        let height = dispatch_state.current_pos.y - start_pos.y;
-                        if width_rel / height_rel > width / height {
-                            dispatch_state.end_pos = Some(Position {
-                                x: start_pos.x + height * width_rel / height_rel,
-                                y: start_pos.y + height,
-                            });
+                if dispatch_state.tweak_mode {
+                    if dispatch_state.active_handle.is_some() {
+                        dispatch_state.apply_handle_drag();
+                        dispatch_state.try_commit();
+                    }
+                } else {
+                    dispatch_state.end_pos = None;
+
+                    // NOTE:  when it is area, we just use one click to get the position, so we
+                    // need to know the end_pos immediately. so even the start_pos is not decided, we
+                    // still need an end_pos
+                    if dispatch_state.is_area() || dispatch_state.is_dimensions_or_output() {
+                        if let Some(ratio) = dispatch_state.aspect_ratio {
+                            let width_rel = ratio.0;
+                            let height_rel = ratio.1;
+                            let start_pos = dispatch_state
+                                .start_pos
+                                .unwrap_or(dispatch_state.current_pos);
+                            let width = dispatch_state.current_pos.x - start_pos.x;
+                            let height = dispatch_state.current_pos.y - start_pos.y;
+                            if width_rel / height_rel > width / height {
+                                dispatch_state.end_pos = Some(Position {
+                                    x: start_pos.x + height * width_rel / height_rel,
+                                    y: start_pos.y + height,
+                                });
+                            } else {
+                                dispatch_state.end_pos = Some(Position {
+                                    x: start_pos.x + width,
+                                    y: start_pos.y + width * height_rel / width_rel,
+                                });
+                            }
                         } else {
+                            dispatch_state.end_pos = Some(dispatch_state.current_pos);
+                        }
+                        dispatch_state.try_commit();
+                    } else if dispatch_state.is_predefined_boxes() {
+                        let current_pos = dispatch_state.current_pos;
+                        if let Some(box_info) = dispatch_state
+                            .predefined_boxes
+                            .clone()
+                            .unwrap()
+                            .iter()
+                            .find(|box_info| {
+                                current_pos.x >= box_info.start_x
+                                    && current_pos.x <= box_info.end_x
+                                    && current_pos.y >= box_info.start_y
+                                    && current_pos.y <= box_info.end_y
+                            })
+                        {
+                            dispatch_state.end_pos = Some(dispatch_state.current_pos);
+                            dispatch_state.set_start_pos(Position {
+                                x: box_info.start_x,
+                                y: box_info.start_y,
+                            });
                             dispatch_state.end_pos = Some(Position {
-                                x: start_pos.x + width,
-                                y: start_pos.y + width * height_rel / width_rel,
+                                x: box_info.end_x,
+                                y: box_info.end_y,
                             });
                         }
-                    } else {
-                        dispatch_state.end_pos = Some(dispatch_state.current_pos);
+                        dispatch_state.try_commit();
                     }
-                    dispatch_state.try_commit();
-                } else if dispatch_state.is_predefined_boxes() {
-                    let current_pos = dispatch_state.current_pos;
-                    if let Some(box_info) = dispatch_state
-                        .predefined_boxes
-                        .clone()
-                        .unwrap()
-                        .iter()
-                        .find(|box_info| {
-                            current_pos.x >= box_info.start_x
-                                && current_pos.x <= box_info.end_x
-                                && current_pos.y >= box_info.start_y
-                                && current_pos.y <= box_info.end_y
-                        })
-                    {
-                        dispatch_state.end_pos = Some(dispatch_state.current_pos);
-                        dispatch_state.set_start_pos(Position {
-                            x: box_info.start_x,
-                            y: box_info.start_y,
-                        });
-                        dispatch_state.end_pos = Some(Position {
-                            x: box_info.end_x,
-                            y: box_info.end_y,
-                        });
-                    }
-                    dispatch_state.try_commit();
                 }
             }
             _ => {}

--- a/libwaysip/src/lib.rs
+++ b/libwaysip/src/lib.rs
@@ -57,6 +57,8 @@ pub struct WaySip {
     #[cfg(feature = "benchmark")]
     bench: bool,
     background_provider: Option<BackgroundProvider>,
+    tweak: bool,
+    confirm_key: Option<u32>,
 }
 
 impl fmt::Debug for WaySip {
@@ -72,6 +74,8 @@ impl fmt::Debug for WaySip {
         debug.field("bench", &self.bench);
         debug
             .field("background_provider", &self.background_provider.is_some())
+            .field("tweak", &self.tweak)
+            .field("confirm_key", &self.confirm_key)
             .finish()
     }
 }
@@ -132,6 +136,23 @@ impl WaySip {
         self
     }
 
+    /// Enable "tweak before confirming": after the initial drag/click for an
+    /// area selection finishes, four draggable corner handles appear instead
+    /// of finishing immediately. The selection is confirmed by pressing the
+    /// confirm key (see [`WaySip::with_confirm_key`], Enter by default).
+    pub fn with_tweak(mut self) -> Self {
+        self.tweak = true;
+        self
+    }
+
+    /// Overrides the key (as a Linux evdev keycode) used to confirm a tweaked
+    /// selection. Defaults to Enter. Only has an effect when combined with
+    /// [`WaySip::with_tweak`].
+    pub fn with_confirm_key(mut self, key: u32) -> Self {
+        self.confirm_key = Some(key);
+        self
+    }
+
     #[cfg(feature = "benchmark")]
     pub fn with_bench(mut self) -> Self {
         self.bench = true;
@@ -167,6 +188,8 @@ impl WaySip {
                 #[cfg(feature = "benchmark")]
                 bench,
                 self.background_provider,
+                self.tweak,
+                self.confirm_key,
             ),
             None => {
                 let connection = Connection::connect_to_env()
@@ -181,12 +204,15 @@ impl WaySip {
                     #[cfg(feature = "benchmark")]
                     bench,
                     self.background_provider,
+                    self.tweak,
+                    self.confirm_key,
                 )
             }
         }
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn get_area_inner(
     connection: &Connection,
     selection_type: SelectionType,
@@ -195,10 +221,17 @@ fn get_area_inner(
     aspect_ratio: Option<(f64, f64)>,
     #[cfg(feature = "benchmark")] bench: bool,
     background_provider: Option<BackgroundProvider>,
+    tweak: bool,
+    confirm_key: Option<u32>,
 ) -> Result<Option<state::AreaInfo>, WaySipError> {
     let (globals, _) = registry_queue_init::<state::WaysipState>(connection)
         .map_err(|e| WaySipError::InitFailed(e.to_string()))?;
     let mut state = state::WaysipState::new(selection_type);
+
+    state.tweak_enabled = tweak;
+    if let Some(key) = confirm_key {
+        state.confirm_key = key;
+    }
 
     state.predefined_boxes = boxes;
     state.aspect_ratio = aspect_ratio;

--- a/libwaysip/src/lib.rs
+++ b/libwaysip/src/lib.rs
@@ -57,7 +57,7 @@ pub struct WaySip {
     #[cfg(feature = "benchmark")]
     bench: bool,
     background_provider: Option<BackgroundProvider>,
-    tweak: bool,
+    edit_selection: bool,
     confirm_key: Option<u32>,
 }
 
@@ -74,7 +74,7 @@ impl fmt::Debug for WaySip {
         debug.field("bench", &self.bench);
         debug
             .field("background_provider", &self.background_provider.is_some())
-            .field("tweak", &self.tweak)
+            .field("edit_selection", &self.edit_selection)
             .field("confirm_key", &self.confirm_key)
             .finish()
     }
@@ -136,18 +136,19 @@ impl WaySip {
         self
     }
 
-    /// Enable "tweak before confirming": after the initial drag/click for an
-    /// area selection finishes, four draggable corner handles appear instead
-    /// of finishing immediately. The selection is confirmed by pressing the
-    /// confirm key (see [`WaySip::with_confirm_key`], Enter by default).
-    pub fn with_tweak(mut self) -> Self {
-        self.tweak = true;
+    /// Enable "edit selection before confirming": after the initial drag/click
+    /// for an area selection finishes, four draggable corner handles appear
+    /// instead of finishing immediately. The selection is confirmed by
+    /// pressing the confirm key (see [`WaySip::with_confirm_key`], Enter by
+    /// default).
+    pub fn with_edit_selection(mut self) -> Self {
+        self.edit_selection = true;
         self
     }
 
-    /// Overrides the key (as a Linux evdev keycode) used to confirm a tweaked
+    /// Overrides the key (as a Linux evdev keycode) used to confirm an edited
     /// selection. Defaults to Enter. Only has an effect when combined with
-    /// [`WaySip::with_tweak`].
+    /// [`WaySip::with_edit_selection`].
     pub fn with_confirm_key(mut self, key: u32) -> Self {
         self.confirm_key = Some(key);
         self
@@ -188,7 +189,7 @@ impl WaySip {
                 #[cfg(feature = "benchmark")]
                 bench,
                 self.background_provider,
-                self.tweak,
+                self.edit_selection,
                 self.confirm_key,
             ),
             None => {
@@ -204,7 +205,7 @@ impl WaySip {
                     #[cfg(feature = "benchmark")]
                     bench,
                     self.background_provider,
-                    self.tweak,
+                    self.edit_selection,
                     self.confirm_key,
                 )
             }
@@ -221,14 +222,14 @@ fn get_area_inner(
     aspect_ratio: Option<(f64, f64)>,
     #[cfg(feature = "benchmark")] bench: bool,
     background_provider: Option<BackgroundProvider>,
-    tweak: bool,
+    edit_selection: bool,
     confirm_key: Option<u32>,
 ) -> Result<Option<state::AreaInfo>, WaySipError> {
     let (globals, _) = registry_queue_init::<state::WaysipState>(connection)
         .map_err(|e| WaySipError::InitFailed(e.to_string()))?;
     let mut state = state::WaysipState::new(selection_type);
 
-    state.tweak_enabled = tweak;
+    state.edit_enabled = edit_selection;
     if let Some(key) = confirm_key {
         state.confirm_key = key;
     }

--- a/libwaysip/src/render.rs
+++ b/libwaysip/src/render.rs
@@ -117,6 +117,7 @@ impl LayerSurfaceInfo {
         draw_text: bool,
         opt_boxes: Option<&Vec<BoxInfo>>,
         redraw_all: bool,
+        show_handles: bool,
     ) {
         let cairoinfo = &self.cairo_t;
         let frozen = self.frozen_bg.as_ref();
@@ -129,7 +130,12 @@ impl LayerSurfaceInfo {
             [rx1, ry1, rx2, ry2]
         };
 
-        let border_margin = self.style.border_weight + 2.0;
+        let handle_radius = (self.style.border_weight * 3.0).max(5.0);
+        let border_margin = if show_handles {
+            (self.style.border_weight + 2.0).max(handle_radius + 2.0)
+        } else {
+            self.style.border_weight + 2.0
+        };
 
         let (text_margin_w, text_margin_h) = *self.margin.get_or_init(|| {
             if !draw_text {
@@ -253,6 +259,35 @@ impl LayerSurfaceInfo {
         );
         cairoinfo.set_line_width(self.style.border_weight);
         cairoinfo.stroke().unwrap();
+
+        if show_handles {
+            let handles = [
+                (relate_start_x, relate_start_y),
+                (relate_end_x, relate_start_y),
+                (relate_start_x, relate_end_y),
+                (relate_end_x, relate_end_y),
+            ];
+            for (hx, hy) in handles {
+                cairoinfo.save().unwrap();
+                cairoinfo.arc(hx, hy, handle_radius, 0.0, std::f64::consts::TAU);
+                cairoinfo.set_source_rgba(
+                    self.style.border_text_color.r,
+                    self.style.border_text_color.g,
+                    self.style.border_text_color.b,
+                    self.style.border_text_color.a,
+                );
+                cairoinfo.fill_preserve().unwrap();
+                cairoinfo.set_source_rgba(
+                    self.style.background_color.r,
+                    self.style.background_color.g,
+                    self.style.background_color.b,
+                    1.0,
+                );
+                cairoinfo.set_line_width(1.5);
+                cairoinfo.stroke().unwrap();
+                cairoinfo.restore().unwrap();
+            }
+        }
 
         if draw_text {
             let font_size = self.style.font_size;

--- a/libwaysip/src/state.rs
+++ b/libwaysip/src/state.rs
@@ -36,10 +36,10 @@ pub enum SelectionType {
 }
 
 /// Linux evdev keycode for the Enter key, used as the default hotkey to confirm
-/// a tweaked selection.
+/// an edited selection.
 pub(crate) const DEFAULT_CONFIRM_KEY: u32 = 28;
 
-/// Identifies one of the four corner drag-handles shown while tweaking a selection.
+/// Identifies one of the four corner drag-handles shown while editing a selection.
 /// Each variant names which of `start_pos`/`end_pos` (or combination of their axes)
 /// the handle controls, so dragging keeps working sensibly even if the rectangle
 /// gets flipped around during the drag.
@@ -208,13 +208,13 @@ pub struct WaysipState {
     /// Time when mouse was pressed down
     pub(crate) mouse_press_time: Option<std::time::Instant>,
     redraw_all: bool,
-    /// Whether the "tweak before confirming" feature is enabled
-    pub(crate) tweak_enabled: bool,
-    /// Keycode (evdev) that confirms a tweaked selection
+    /// Whether the "edit selection before confirming" feature is enabled
+    pub(crate) edit_enabled: bool,
+    /// Keycode (evdev) that confirms an edited selection
     pub(crate) confirm_key: u32,
-    /// Whether the initial drag has finished and the user is now free to tweak
+    /// Whether the initial drag has finished and the user is now free to edit
     /// the rectangle's corners before confirming
-    pub(crate) tweak_mode: bool,
+    pub(crate) editing: bool,
     /// The corner handle currently being dragged, if any
     pub(crate) active_handle: Option<Corner>,
 }
@@ -244,9 +244,9 @@ impl WaysipState {
             effective_selection_type: None,
             mouse_press_time: None,
             redraw_all: false,
-            tweak_enabled: false,
+            edit_enabled: false,
             confirm_key: DEFAULT_CONFIRM_KEY,
-            tweak_mode: false,
+            editing: false,
             active_handle: None,
         }
     }
@@ -417,9 +417,9 @@ impl WaysipState {
         }
     }
 
-    pub(crate) fn finish_or_enter_tweak(&mut self) {
-        if self.tweak_enabled && self.is_effective_area() {
-            self.tweak_mode = true;
+    pub(crate) fn finish_or_start_editing(&mut self) {
+        if self.edit_enabled && self.is_effective_area() {
+            self.editing = true;
         } else {
             self.running = false;
         }
@@ -506,7 +506,7 @@ impl WaysipState {
             let end_pos = self.end_pos.unwrap_or(start_pos);
             let draw_text =
                 self.is_area() || self.is_effective_area() || self.is_dimensions_or_output();
-            let show_handles = self.tweak_enabled && self.tweak_mode;
+            let show_handles = self.edit_enabled && self.editing;
 
             self.wl_surfaces[screen_index].redraw(
                 start_pos,

--- a/libwaysip/src/state.rs
+++ b/libwaysip/src/state.rs
@@ -39,16 +39,35 @@ pub enum SelectionType {
 /// an edited selection.
 pub(crate) const DEFAULT_CONFIRM_KEY: u32 = 28;
 
-/// Identifies one of the four corner drag-handles shown while editing a selection.
-/// Each variant names which of `start_pos`/`end_pos` (or combination of their axes)
-/// the handle controls, so dragging keeps working sensibly even if the rectangle
-/// gets flipped around during the drag.
+/// Identifies what is being dragged while editing a selection: either one of
+/// the four corner handles, or the whole rectangle.
+/// Each corner variant names which of `start_pos`/`end_pos` (or combination of
+/// their axes) the handle controls, so dragging keeps working sensibly even if
+/// the rectangle gets flipped around during the drag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DragTarget {
+    Corner(Corner),
+    /// The interior of the rectangle: dragging it moves the whole selection.
+    Body,
+}
+
+/// One of the four corner handles of the selection rectangle.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Corner {
     Start,
     End,
     EndXStartY,
     StartXEndY,
+}
+
+/// Snapshot taken when the user starts dragging the whole rectangle (as
+/// opposed to a single corner handle), so the rectangle can be translated by
+/// the mouse movement delta without drifting.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MoveAnchor {
+    pub grab_pos: Position<f64>,
+    pub start_pos: Position<f64>,
+    pub end_pos: Position<f64>,
 }
 
 #[derive(Debug, Clone)]
@@ -215,8 +234,10 @@ pub struct WaysipState {
     /// Whether the initial drag has finished and the user is now free to edit
     /// the rectangle's corners before confirming
     pub(crate) editing: bool,
-    /// The corner handle currently being dragged, if any
-    pub(crate) active_handle: Option<Corner>,
+    /// The corner handle or rectangle body currently being dragged, if any
+    pub(crate) active_handle: Option<DragTarget>,
+    /// Snapshot used while dragging the rectangle body (see [`DragTarget::Body`])
+    pub(crate) move_anchor: Option<MoveAnchor>,
 }
 
 impl WaysipState {
@@ -248,6 +269,7 @@ impl WaysipState {
             confirm_key: DEFAULT_CONFIRM_KEY,
             editing: false,
             active_handle: None,
+            move_anchor: None,
         }
     }
 
@@ -390,15 +412,61 @@ impl WaysipState {
             .map(|(corner, _)| corner)
     }
 
+    /// Same as [`Self::hit_test_handle`], but wraps the result in
+    /// [`DragTarget::Corner`] for use alongside [`DragTarget::Body`].
+    fn hit_test_corner_handle(&self, pos: Position<f64>) -> Option<DragTarget> {
+        self.hit_test_handle(pos).map(DragTarget::Corner)
+    }
+
+    /// Returns whether `pos` is inside the current selection rectangle
+    /// (regardless of which of `start_pos`/`end_pos` is visually top-left).
+    fn contains(&self, pos: Position<f64>) -> bool {
+        let Some(start) = self.start_pos else {
+            return false;
+        };
+        let Some(end) = self.end_pos else {
+            return false;
+        };
+        let (x1, x2) = (start.x.min(end.x), start.x.max(end.x));
+        let (y1, y2) = (start.y.min(end.y), start.y.max(end.y));
+        pos.x >= x1 && pos.x <= x2 && pos.y >= y1 && pos.y <= y2
+    }
+
+    /// Finds what dragging at `pos` should affect: a corner handle if close
+    /// enough to one, otherwise a whole-rectangle move if `pos` is inside the
+    /// selection, otherwise `None`.
+    pub(crate) fn hit_test(&self, pos: Position<f64>) -> Option<DragTarget> {
+        self.hit_test_corner_handle(pos).or_else(|| {
+            if self.contains(pos) {
+                Some(DragTarget::Body)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Records the starting point of a whole-rectangle drag so it can be
+    /// translated by the mouse movement delta without drifting.
+    pub(crate) fn begin_move_drag(&mut self) {
+        let (Some(start_pos), Some(end_pos)) = (self.start_pos, self.end_pos) else {
+            return;
+        };
+        self.move_anchor = Some(MoveAnchor {
+            grab_pos: self.current_pos,
+            start_pos,
+            end_pos,
+        });
+    }
+
     pub(crate) fn apply_handle_drag(&mut self) {
-        let Some(corner) = self.active_handle else {
+        let Some(target) = self.active_handle else {
             return;
         };
         let pos = self.current_pos;
-        match corner {
-            Corner::Start => self.start_pos = Some(pos),
-            Corner::End => self.end_pos = Some(pos),
-            Corner::EndXStartY => {
+        match target {
+            DragTarget::Corner(Corner::Start) => self.start_pos = Some(pos),
+            DragTarget::Corner(Corner::End) => self.end_pos = Some(pos),
+            DragTarget::Corner(Corner::EndXStartY) => {
                 if let Some(end) = self.end_pos.as_mut() {
                     end.x = pos.x;
                 }
@@ -406,13 +474,28 @@ impl WaysipState {
                     start.y = pos.y;
                 }
             }
-            Corner::StartXEndY => {
+            DragTarget::Corner(Corner::StartXEndY) => {
                 if let Some(start) = self.start_pos.as_mut() {
                     start.x = pos.x;
                 }
                 if let Some(end) = self.end_pos.as_mut() {
                     end.y = pos.y;
                 }
+            }
+            DragTarget::Body => {
+                let Some(anchor) = self.move_anchor else {
+                    return;
+                };
+                let dx = pos.x - anchor.grab_pos.x;
+                let dy = pos.y - anchor.grab_pos.y;
+                self.start_pos = Some(Position {
+                    x: anchor.start_pos.x + dx,
+                    y: anchor.start_pos.y + dy,
+                });
+                self.end_pos = Some(Position {
+                    x: anchor.end_pos.x + dx,
+                    y: anchor.end_pos.y + dy,
+                });
             }
         }
     }

--- a/libwaysip/src/state.rs
+++ b/libwaysip/src/state.rs
@@ -35,6 +35,22 @@ pub enum SelectionType {
     DimensionsOrOutput,
 }
 
+/// Linux evdev keycode for the Enter key, used as the default hotkey to confirm
+/// a tweaked selection.
+pub(crate) const DEFAULT_CONFIRM_KEY: u32 = 28;
+
+/// Identifies one of the four corner drag-handles shown while tweaking a selection.
+/// Each variant names which of `start_pos`/`end_pos` (or combination of their axes)
+/// the handle controls, so dragging keeps working sensibly even if the rectangle
+/// gets flipped around during the drag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Corner {
+    Start,
+    End,
+    EndXStartY,
+    StartXEndY,
+}
+
 #[derive(Debug, Clone)]
 pub struct ZXdgOutputInfo {
     pub zxdg_output: zxdg_output_v1::ZxdgOutputV1,
@@ -192,6 +208,15 @@ pub struct WaysipState {
     /// Time when mouse was pressed down
     pub(crate) mouse_press_time: Option<std::time::Instant>,
     redraw_all: bool,
+    /// Whether the "tweak before confirming" feature is enabled
+    pub(crate) tweak_enabled: bool,
+    /// Keycode (evdev) that confirms a tweaked selection
+    pub(crate) confirm_key: u32,
+    /// Whether the initial drag has finished and the user is now free to tweak
+    /// the rectangle's corners before confirming
+    pub(crate) tweak_mode: bool,
+    /// The corner handle currently being dragged, if any
+    pub(crate) active_handle: Option<Corner>,
 }
 
 impl WaysipState {
@@ -219,6 +244,10 @@ impl WaysipState {
             effective_selection_type: None,
             mouse_press_time: None,
             redraw_all: false,
+            tweak_enabled: false,
+            confirm_key: DEFAULT_CONFIRM_KEY,
+            tweak_mode: false,
+            active_handle: None,
         }
     }
 
@@ -324,6 +353,78 @@ impl WaysipState {
         self.start_pos = Some(start_pos);
     }
 
+    pub(crate) fn corners(&self) -> Option<[(Corner, Position<f64>); 4]> {
+        let start = self.start_pos?;
+        let end = self.end_pos?;
+        Some([
+            (Corner::Start, start),
+            (Corner::End, end),
+            (
+                Corner::EndXStartY,
+                Position {
+                    x: end.x,
+                    y: start.y,
+                },
+            ),
+            (
+                Corner::StartXEndY,
+                Position {
+                    x: start.x,
+                    y: end.y,
+                },
+            ),
+        ])
+    }
+
+    pub(crate) fn hit_test_handle(&self, pos: Position<f64>) -> Option<Corner> {
+        const HIT_RADIUS: f64 = 14.0;
+        self.corners()?
+            .into_iter()
+            .map(|(corner, corner_pos)| {
+                let dx = corner_pos.x - pos.x;
+                let dy = corner_pos.y - pos.y;
+                (corner, (dx * dx + dy * dy).sqrt())
+            })
+            .filter(|(_, dist)| *dist <= HIT_RADIUS)
+            .min_by(|a, b| a.1.total_cmp(&b.1))
+            .map(|(corner, _)| corner)
+    }
+
+    pub(crate) fn apply_handle_drag(&mut self) {
+        let Some(corner) = self.active_handle else {
+            return;
+        };
+        let pos = self.current_pos;
+        match corner {
+            Corner::Start => self.start_pos = Some(pos),
+            Corner::End => self.end_pos = Some(pos),
+            Corner::EndXStartY => {
+                if let Some(end) = self.end_pos.as_mut() {
+                    end.x = pos.x;
+                }
+                if let Some(start) = self.start_pos.as_mut() {
+                    start.y = pos.y;
+                }
+            }
+            Corner::StartXEndY => {
+                if let Some(start) = self.start_pos.as_mut() {
+                    start.x = pos.x;
+                }
+                if let Some(end) = self.end_pos.as_mut() {
+                    end.y = pos.y;
+                }
+            }
+        }
+    }
+
+    pub(crate) fn finish_or_enter_tweak(&mut self) {
+        if self.tweak_enabled && self.is_effective_area() {
+            self.tweak_mode = true;
+        } else {
+            self.running = false;
+        }
+    }
+
     pub fn commit(&self) {
         let qh = self.qh.as_ref().unwrap();
         for (idx, surface) in self.wl_surfaces.iter().enumerate() {
@@ -405,6 +506,7 @@ impl WaysipState {
             let end_pos = self.end_pos.unwrap_or(start_pos);
             let draw_text =
                 self.is_area() || self.is_effective_area() || self.is_dimensions_or_output();
+            let show_handles = self.tweak_enabled && self.tweak_mode;
 
             self.wl_surfaces[screen_index].redraw(
                 start_pos,
@@ -414,6 +516,7 @@ impl WaysipState {
                 draw_text,
                 self.predefined_boxes.as_ref(),
                 self.redraw_all,
+                show_handles,
             );
         }
     }

--- a/libwaysip/src/state.rs
+++ b/libwaysip/src/state.rs
@@ -238,6 +238,13 @@ pub struct WaysipState {
     pub(crate) active_handle: Option<DragTarget>,
     /// Snapshot used while dragging the rectangle body (see [`DragTarget::Body`])
     pub(crate) move_anchor: Option<MoveAnchor>,
+    /// Serial of the most recent `wl_pointer` enter/button event, needed to
+    /// change the cursor shape outside of those events (e.g. on motion)
+    pub(crate) last_pointer_serial: Option<u32>,
+    /// Whether the pointer's cursor is currently showing the crosshair shape
+    /// (as opposed to the default system cursor), used to avoid redundant
+    /// cursor-shape requests
+    pub(crate) cursor_is_crosshair: Option<bool>,
 }
 
 impl WaysipState {
@@ -270,6 +277,8 @@ impl WaysipState {
             editing: false,
             active_handle: None,
             move_anchor: None,
+            last_pointer_serial: None,
+            cursor_is_crosshair: None,
         }
     }
 

--- a/waysip/src/cli.rs
+++ b/waysip/src/cli.rs
@@ -105,6 +105,16 @@ pub struct Cli {
     )]
     pub aspect_ratio: Option<String>,
 
+    /// Allow tweaking the selection (drag its 4 corner handles) before
+    /// confirming with the confirm key (Enter by default, see --tweak-key).
+    #[arg(long, conflicts_with_all = ["point", "screen", "boxes"])]
+    pub tweak: bool,
+
+    /// Linux evdev keycode used to confirm a tweaked selection. Defaults to
+    /// Enter (28). Only takes effect when combined with --tweak.
+    #[arg(long, value_name = "keycode", requires = "tweak")]
+    pub tweak_key: Option<u32>,
+
     // ─── Global options ───────────────────────────────────────────────────────
     /// Log level written to stderr.
     #[cfg(feature = "logger")]

--- a/waysip/src/cli.rs
+++ b/waysip/src/cli.rs
@@ -105,15 +105,15 @@ pub struct Cli {
     )]
     pub aspect_ratio: Option<String>,
 
-    /// Allow tweaking the selection (drag its 4 corner handles) before
-    /// confirming with the confirm key (Enter by default, see --tweak-key).
-    #[arg(long, conflicts_with_all = ["point", "screen", "boxes"])]
-    pub tweak: bool,
+    /// Adjust the selection (drag its 4 corner handles) before confirming
+    /// with the confirm key (Enter by default, see --edit-selection-key).
+    #[arg(short = 'e', long, conflicts_with_all = ["point", "screen", "boxes"])]
+    pub edit_selection: bool,
 
-    /// Linux evdev keycode used to confirm a tweaked selection. Defaults to
-    /// Enter (28). Only takes effect when combined with --tweak.
-    #[arg(long, value_name = "keycode", requires = "tweak")]
-    pub tweak_key: Option<u32>,
+    /// Linux evdev keycode used to confirm an edited selection. Defaults to
+    /// Enter (28). Only takes effect when combined with --edit-selection.
+    #[arg(long, value_name = "keycode", requires = "edit_selection")]
+    pub edit_selection_key: Option<u32>,
 
     // ─── Global options ───────────────────────────────────────────────────────
     /// Log level written to stderr.

--- a/waysip/src/settings.rs
+++ b/waysip/src/settings.rs
@@ -110,9 +110,9 @@ pub(crate) fn run_selection(
         builder = builder.with_aspect_ratio(width, height);
     }
 
-    if args.tweak {
-        builder = builder.with_tweak();
-        if let Some(key) = args.tweak_key.take() {
+    if args.edit_selection {
+        builder = builder.with_edit_selection();
+        if let Some(key) = args.edit_selection_key.take() {
             builder = builder.with_confirm_key(key);
         }
     }

--- a/waysip/src/settings.rs
+++ b/waysip/src/settings.rs
@@ -110,6 +110,13 @@ pub(crate) fn run_selection(
         builder = builder.with_aspect_ratio(width, height);
     }
 
+    if args.tweak {
+        builder = builder.with_tweak();
+        if let Some(key) = args.tweak_key.take() {
+            builder = builder.with_confirm_key(key);
+        }
+    }
+
     #[cfg(feature = "benchmark")]
     if args.bench {
         builder = builder.with_bench();


### PR DESCRIPTION
This PR adds a new feature to edit the selected area before printing the resulting output.
To be more precise, the code allows changing selection rectangle bounds, allows dragging rectangle around, shows crosshair cursor when in selection area.
The code is behind a new flags: `--edit-selection`/`-e` and `--edit-selection-key <keycode>`. Since this doesn't introduce any new deps I decided that it'd be an overkill to separate it behind cargo feat.The consumers that doesn't use this feat will not be affected by this change.

Closes: #6 

https://github.com/user-attachments/assets/1ba810b4-0d0a-4d5d-8861-ea81835d6364

One thing I only not sure is, the out of bounds cases. By dragging rectangle out of screen we can see the negative/overflow values:

https://github.com/user-attachments/assets/7f6af1aa-d6c2-4792-b790-c88622136244

For consumers (e.g. `wayshot`) that expects a correct string, out-of-bounds results will result in panic. I wonder, if we should add a guards here, like setting making negative values to `0` before outputting them, or it is fine as-is.